### PR TITLE
Tech: eventing massive updates for version 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ and **flexible** custom elements to easily create basic UX modules and make your
 - ##### [ESL Media](./src/modules/esl-media/README.md)
 - ##### [ESL Scrollbar](./src/modules/esl-scrollbar/README.md)
 
-- ##### [ESL Base Popup](src/modules/esl-base-popup/README.md)
+- ##### [ESL Base Popup](./src/modules/esl-base-popup/README.md)
 - ##### [ESL Popup](./src/modules/esl-popup/README.md)
 - ##### [ESL Trigger](./src/modules/esl-trigger/README.md)
 - ##### [ESL Panel and Panel Stack](./src/modules/esl-panel/README.md)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ and **flexible** custom elements to easily create basic UX modules and make your
 - ##### [ESL Media](./src/modules/esl-media/README.md)
 - ##### [ESL Scrollbar](./src/modules/esl-scrollbar/README.md)
 
-- ##### [ESL Base Popup](./src/modules/esl-base-popup/README.md)
+- ##### [ESL Base Popup](src/modules/esl-base-popup/README.md)
 - ##### [ESL Popup](./src/modules/esl-popup/README.md)
 - ##### [ESL Trigger](./src/modules/esl-trigger/README.md)
 - ##### [ESL Panel and Panel Stack](./src/modules/esl-panel/README.md)

--- a/src/modules/draft/esl-carousel/core/esl-carousel.ts
+++ b/src/modules/draft/esl-carousel/core/esl-carousel.ts
@@ -18,7 +18,6 @@ export class ESLCarousel extends ESLBaseElement {
   public static Slide = ESLCarouselSlide;
 
   public static is = 'esl-carousel';
-  public static eventNs = 'esl:carousel';
 
   static get observedAttributes() {
     return ['config'];
@@ -115,7 +114,7 @@ export class ESLCarousel extends ESLBaseElement {
       }
     };
 
-    const approved = this.$$fireNs('slide:change', eventDetails);
+    const approved = this.$$fire('slide:change', eventDetails);
 
     if (this._view && approved && this.firstIndex !== nextIndex) {
       this._view.goTo(nextIndex, direction);
@@ -138,7 +137,7 @@ export class ESLCarousel extends ESLBaseElement {
       }
     }
 
-    this.$$fireNs('slide:changed', eventDetails);
+    this.$$fire('slide:changed', eventDetails);
   }
 
   public prev() {

--- a/src/modules/draft/esl-carousel/plugin/esl-carousel-autoplay.plugin.ts
+++ b/src/modules/draft/esl-carousel/plugin/esl-carousel-autoplay.plugin.ts
@@ -33,7 +33,7 @@ export class ESLCarouselAutoplayPlugin extends ESLCarouselPlugin {
     this.carousel.addEventListener('mouseout', this._onInteract);
     this.carousel.addEventListener('focusin', this._onInteract);
     this.carousel.addEventListener('focusout', this._onInteract);
-    this.carousel.addEventListener('esl:carousel:slide:changed', this._onInteract);
+    this.carousel.addEventListener('slide:changed', this._onInteract);
     this.start();
     // console.log('Auto-advance plugin attached successfully to ', this.carousel);
   }
@@ -42,7 +42,7 @@ export class ESLCarouselAutoplayPlugin extends ESLCarouselPlugin {
     this.carousel.removeEventListener('mouseout', this._onInteract);
     this.carousel.removeEventListener('focusin', this._onInteract);
     this.carousel.removeEventListener('focusout', this._onInteract);
-    this.carousel.removeEventListener('esl:carousel:slide:changed', this._onInteract);
+    this.carousel.removeEventListener('slide:changed', this._onInteract);
     this.stop();
     // console.log('Auto-advance plugin detached successfully from ', this.carousel);
   }
@@ -84,7 +84,7 @@ export class ESLCarouselAutoplayPlugin extends ESLCarouselPlugin {
       case 'focusout':
         this.start();
         return;
-      case 'eslc:slide:changed':
+      case 'slide:changed':
         this.reset();
         return;
     }

--- a/src/modules/draft/esl-carousel/plugin/esl-carousel-dots.plugin.ts
+++ b/src/modules/draft/esl-carousel/plugin/esl-carousel-dots.plugin.ts
@@ -16,12 +16,12 @@ export class ESLCarouselDotsPlugin extends ESLCarouselPlugin {
 
   public bind() {
     this.rerender();
-    this.carousel.addEventListener('esl:carousel:slide:changed', this._onUpdate);
+    this.carousel.addEventListener('slide:changed', this._onUpdate);
   }
 
   public unbind() {
     this.innerHTML = '';
-    this.carousel.removeEventListener('esl:carousel:slide:changed', this._onUpdate);
+    this.carousel.removeEventListener('slide:changed', this._onUpdate);
   }
 
   public rerender() {

--- a/src/modules/draft/esl-carousel/plugin/esl-carousel-link.plugin.ts
+++ b/src/modules/draft/esl-carousel/plugin/esl-carousel-link.plugin.ts
@@ -31,16 +31,16 @@ export class ESLCarouselLinkPlugin extends ESLCarouselPlugin {
     if (!(this.target instanceof ESLCarousel)) return;
 
     if (this.direction === 'both' || this.direction === 'reverse') {
-      this.target.addEventListener('esl:carousel:slide:changed', this._onSlideChange);
+      this.target.addEventListener('slide:changed', this._onSlideChange);
     }
     if (this.direction === 'both' || this.direction === 'target') {
-      this.carousel.addEventListener('esl:carousel:slide:changed', this._onSlideChange);
+      this.carousel.addEventListener('slide:changed', this._onSlideChange);
     }
   }
 
   public unbind() {
-    this.target && this.target.removeEventListener('esl:carousel:slide:changed', this._onSlideChange);
-    this.carousel && this.carousel.removeEventListener('esl:carousel:slide:changed', this._onSlideChange);
+    this.target && this.target.removeEventListener('slide:changed', this._onSlideChange);
+    this.carousel && this.carousel.removeEventListener('slide:changed', this._onSlideChange);
   }
 
   protected _onSlideChange(e: CustomEvent) {

--- a/src/modules/esl-base-element/core.ts
+++ b/src/modules/esl-base-element/core.ts
@@ -1,4 +1,5 @@
 export * from './core/esl-base-element';
+
 export * from './decorators/attr';
 export * from './decorators/bool-attr';
 export * from './decorators/json-attr';

--- a/src/modules/esl-base-element/core/esl-base-element.ts
+++ b/src/modules/esl-base-element/core/esl-base-element.ts
@@ -5,8 +5,6 @@
 export abstract class ESLBaseElement extends HTMLElement {
   /** Custom element tag name */
   public static is = '';
-  /** ESL custom element event prefix (namespace) */
-  public static eventNs = '';
 
   protected _connected: boolean = false;
 
@@ -31,22 +29,13 @@ export abstract class ESLBaseElement extends HTMLElement {
    * @param eventName - event name
    * @param [eventInit] - custom event init. See {@link CustomEventInit}
    */
-  public $$fire(eventName: string, eventInit: CustomEventInit = {}): boolean {
-    const init = Object.assign({bubbles: true, cancelable: true}, eventInit);
+  public $$fire(eventName: string, eventInit?: CustomEventInit): boolean {
+    const init = Object.assign({
+      bubbles: true,
+      composed: true,
+      cancelable: true
+    }, eventInit || {});
     return this.dispatchEvent(new CustomEvent(eventName, init));
-  }
-
-  /**
-   * Dispatch component custom event.
-   * Event bubbles and is cancelable by default, use {@param eventInit} to override that.
-   * Will append prefix from static property {@link eventNs} if it is defined.
-   * @param eventName - event name
-   * @param [eventInit] - custom event init. See {@link CustomEventInit}
-   */
-  public $$fireNs(eventName: string, eventInit: CustomEventInit = {}): boolean {
-    const component = this.constructor as typeof ESLBaseElement;
-    const eventFullName = (component.eventNs ? `${component.eventNs}:` : '') + eventName;
-    return this.$$fire(eventFullName, eventInit);
   }
 
   /**

--- a/src/modules/esl-base-element/test/base-element.test.ts
+++ b/src/modules/esl-base-element/test/base-element.test.ts
@@ -59,12 +59,4 @@ describe('ESLBaseElement test', () => {
 
     el.$$fire('testevent');
   }, 10);
-
-  test('FireEvent - bubbling', (done) => {
-    document.addEventListener('esl:test:testevent', (e) => {
-      expect(e).toBeInstanceOf(CustomEvent);
-      done();
-    }, { once: true });
-    el.$$fireNs('testevent');
-  }, 10);
 });

--- a/src/modules/esl-base-popup/core/esl-base-popup.ts
+++ b/src/modules/esl-base-popup/core/esl-base-popup.ts
@@ -141,9 +141,9 @@ export class ESLBasePopup extends ESLBaseElement {
   private planShowTask(params: PopupActionParams) {
     this._task.put(() => {
       if (!params.force && this._open) return;
-      if (!params.silent) this.fireBeforeStateChange();
+      if (!params.silent && !this.$$fireNs('before:show')) return;
       this.onShow(params);
-      if (!params.silent) this.fireStateChange();
+      if (!params.silent && !this.$$fireNs('show')) return;
     }, defined(params.showDelay, params.delay));
   }
 
@@ -160,9 +160,9 @@ export class ESLBasePopup extends ESLBaseElement {
   private planHideTask(params: PopupActionParams) {
     this._task.put(() => {
       if (!params.force && !this._open) return;
-      if (!params.silent) this.fireBeforeStateChange();
+      if (!params.silent && !this.$$fireNs('before:hide')) return;
       this.onHide(params);
-      if (!params.silent) this.fireStateChange();
+      if (!params.silent && !this.$$fireNs('hide')) return;
     }, defined(params.hideDelay, params.delay));
   }
 
@@ -192,6 +192,7 @@ export class ESLBasePopup extends ESLBaseElement {
     CSSUtil.addCls(this, this.activeClass);
     CSSUtil.addCls(document.body, this.bodyClass);
     this.updateA11y();
+    this.$$fire('esl:refresh');
   }
 
   /**
@@ -202,25 +203,6 @@ export class ESLBasePopup extends ESLBaseElement {
     CSSUtil.removeCls(this, this.activeClass);
     CSSUtil.removeCls(document.body, this.bodyClass);
     this.updateA11y();
-  }
-
-  /**
-   * Fires before component state change event
-   */
-  protected fireBeforeStateChange() {
-    this.$$fireNs('beforestatechange', {
-      detail: {open: this._open}
-    });
-  }
-
-  /**
-   * Fires component state change event
-   */
-  protected fireStateChange() {
-    this.$$fireNs('statechange', {
-      detail: {open: this._open}
-    });
-    this.$$fire('esl:refresh');
   }
 
   // "Private" Handlers
@@ -235,7 +217,7 @@ export class ESLBasePopup extends ESLBaseElement {
   protected _onOutsideAction(e: MouseEvent) {
     const target = e.target as HTMLElement;
     if (!this.contains(target)) {
-      this.hide({initiator: 'bodyclick', trigger: target});
+      this.hide({initiator: 'outsideclick', trigger: target});
     }
   }
 

--- a/src/modules/esl-base-popup/core/esl-base-popup.ts
+++ b/src/modules/esl-base-popup/core/esl-base-popup.ts
@@ -141,9 +141,9 @@ export class ESLBasePopup extends ESLBaseElement {
   private planShowTask(params: PopupActionParams) {
     this._task.put(() => {
       if (!params.force && this._open) return;
-      if (!params.silent && !this.$$fireNs('before:show')) return;
+      if (!params.silent && !this.$$fire('before:show')) return;
       this.onShow(params);
-      if (!params.silent && !this.$$fireNs('show')) return;
+      if (!params.silent && !this.$$fire('show')) return;
     }, defined(params.showDelay, params.delay));
   }
 
@@ -160,9 +160,9 @@ export class ESLBasePopup extends ESLBaseElement {
   private planHideTask(params: PopupActionParams) {
     this._task.put(() => {
       if (!params.force && !this._open) return;
-      if (!params.silent && !this.$$fireNs('before:hide')) return;
+      if (!params.silent && !this.$$fire('before:hide')) return;
       this.onHide(params);
-      if (!params.silent && !this.$$fireNs('hide')) return;
+      if (!params.silent && !this.$$fire('hide')) return;
     }, defined(params.hideDelay, params.delay));
   }
 

--- a/src/modules/esl-image/core/esl-image.ts
+++ b/src/modules/esl-image/core/esl-image.ts
@@ -279,8 +279,8 @@ export class ESLImage extends ESLBaseElement {
     this.toggleAttribute('loaded', successful);
     this.toggleAttribute('error', !successful);
     this.toggleAttribute('ready', true);
-    this.$$fire(successful ? 'loaded' : 'error', {bubbles: false});
-    this.$$fire('ready', {bubbles: false});
+    this.$$fire(successful ? 'loaded' : 'error');
+    this.$$fire('ready');
   }
 
   public updateContainerClasses() {
@@ -289,6 +289,10 @@ export class ESLImage extends ESLBaseElement {
     const state = isLoadState(this.containerClassState) && this[this.containerClassState];
     const targetEl = TraversingQuery.first(this.containerClassTarget, this) as HTMLElement;
     targetEl && CSSUtil.toggleClsTo(targetEl, cls, state);
+  }
+
+  public $$fire(eventName: string, eventInit: CustomEventInit = {bubbles: false}): boolean {
+    return super.$$fire(eventName, eventInit);
   }
 
   public static isEmptyImage(src: string) {

--- a/src/modules/esl-media/core/esl-media-manager.ts
+++ b/src/modules/esl-media/core/esl-media-manager.ts
@@ -25,7 +25,7 @@ export class MediaGroupRestrictionManager {
       const current = managerMap.get(instance.group);
       managerMap.set(instance.group, instance);
       if (!current || current === instance || !current.active) return;
-      if (current.$$fireNs('mangedpause')) {
+      if (current.$$fire('mangedpause')) {
         current.pause();
       }
     }

--- a/src/modules/esl-media/core/esl-media.ts
+++ b/src/modules/esl-media/core/esl-media.ts
@@ -231,14 +231,14 @@ export class ESLMedia extends ESLBaseElement {
     this.toggleAttribute('error', false);
     CSSUtil.addCls(this, this.readyClass);
     this.deferredResize();
-    this.$$fireNs('ready');
+    this.$$fire('ready');
   }
 
   public _onError(detail?: any, setReadyState = true) {
     this.toggleAttribute('ready', true);
     this.toggleAttribute('error', true);
-    this.$$fireNs('error', {detail});
-    setReadyState && this.$$fireNs('ready');
+    this.$$fire('error', {detail});
+    setReadyState && this.$$fire('ready');
   }
 
   public _onDetach() {
@@ -246,7 +246,7 @@ export class ESLMedia extends ESLBaseElement {
     this.removeAttribute('ready');
     this.removeAttribute('played');
     CSSUtil.removeCls(this, this.readyClass);
-    this.$$fireNs('detach');
+    this.$$fire('detach');
   }
 
   public _onPlay() {
@@ -254,19 +254,19 @@ export class ESLMedia extends ESLBaseElement {
     this.deferredResize();
     this.setAttribute('active', '');
     this.setAttribute('played', '');
-    this.$$fireNs('play');
+    this.$$fire('play');
     MediaGroupRestrictionManager.registerPlay(this);
   }
 
   public _onPaused() {
     this.removeAttribute('active');
-    this.$$fireNs('paused');
+    this.$$fire('paused');
     MediaGroupRestrictionManager.unregister(this);
   }
 
   public _onEnded() {
     this.removeAttribute('active');
-    this.$$fireNs('ended');
+    this.$$fire('ended');
     MediaGroupRestrictionManager.unregister(this);
   }
 
@@ -340,6 +340,11 @@ export class ESLMedia extends ESLBaseElement {
   public detachViewportConstraint() {
     const observer = getIObserver(true);
     observer && observer.unobserve(this);
+  }
+
+  public $$fire(eventName: string, eventInit?: CustomEventInit): boolean {
+    const name = (this.constructor as typeof ESLMedia).eventNs + eventName;
+    return super.$$fire(name, eventInit);
   }
 }
 

--- a/src/modules/esl-panel/core/esl-panel-stack.ts
+++ b/src/modules/esl-panel/core/esl-panel-stack.ts
@@ -30,14 +30,14 @@ export class ESLPanelStack extends ESLBaseElement {
   }
 
   protected bindEvents() {
-    this.addEventListener(`${ESLPanel.eventNs}:show`, this._onShowPanel);
-    this.addEventListener(`${ESLPanel.eventNs}:before:hide`, this._onBeforeHide);
+    this.addEventListener('show', this._onShowPanel);
+    this.addEventListener('before:hide', this._onBeforeHide);
     this.addEventListener('transitionend', this._onTransitionEnd);
   }
 
   protected unbindEvents() {
-    this.removeEventListener(`${ESLPanel.eventNs}:show`, this._onShowPanel);
-    this.removeEventListener(`${ESLPanel.eventNs}:before:hide`, this._onBeforeHide);
+    this.removeEventListener('show', this._onShowPanel);
+    this.removeEventListener('before:hide', this._onBeforeHide);
     this.removeEventListener('transitionend', this._onTransitionEnd);
   }
 

--- a/src/modules/esl-panel/core/esl-panel-stack.ts
+++ b/src/modules/esl-panel/core/esl-panel-stack.ts
@@ -10,7 +10,6 @@ import ESLPanel from './esl-panel';
 @ExportNs('PanelStack')
 export class ESLPanelStack extends ESLBaseElement {
   public static is = 'esl-panel-stack';
-  public static eventNs = 'esl:panel-stack';
 
   @attr() public accordionTransformation: string;
   @attr({defaultValue: 'animate'}) public animateClass: string;
@@ -31,14 +30,14 @@ export class ESLPanelStack extends ESLBaseElement {
   }
 
   protected bindEvents() {
-    this.addEventListener(`${ESLPanel.eventNs}:statechange`, this._onStateChange);
-    this.addEventListener(`${ESLPanel.eventNs}:beforestatechange`, this._onBeforeStateChange);
+    this.addEventListener(`${ESLPanel.eventNs}:show`, this._onShowPanel);
+    this.addEventListener(`${ESLPanel.eventNs}:before:hide`, this._onBeforeHide);
     this.addEventListener('transitionend', this._onTransitionEnd);
   }
 
   protected unbindEvents() {
-    this.removeEventListener(`${ESLPanel.eventNs}:statechange`, this._onStateChange);
-    this.removeEventListener(`${ESLPanel.eventNs}:beforestatechange`, this._onBeforeStateChange);
+    this.removeEventListener(`${ESLPanel.eventNs}:show`, this._onShowPanel);
+    this.removeEventListener(`${ESLPanel.eventNs}:before:hide`, this._onBeforeHide);
     this.removeEventListener('transitionend', this._onTransitionEnd);
   }
 
@@ -52,8 +51,7 @@ export class ESLPanelStack extends ESLBaseElement {
   }
 
   @bind
-  protected _onStateChange(e: CustomEvent) {
-    if (!e.detail.open) return;
+  protected _onShowPanel(e: CustomEvent) {
     if (this.isAccordion) return;
     const panel = e.target as ESLPanel;
     this.beforeAnimate();
@@ -62,10 +60,9 @@ export class ESLPanelStack extends ESLBaseElement {
   }
 
   @bind
-  protected _onBeforeStateChange(e: CustomEvent) {
-    if (e.detail.open) {
-      this.previousHeight = this.offsetHeight;
-    }
+  protected _onBeforeHide(e: Event) {
+    if (!(e.target as ESLPanel).open) return;
+    this.previousHeight = this.offsetHeight;
   }
 
   protected onAnimate(from?: number, to?: number) {

--- a/src/modules/esl-panel/core/esl-panel.ts
+++ b/src/modules/esl-panel/core/esl-panel.ts
@@ -70,11 +70,10 @@ export class ESLPanel extends ESLBasePopup {
   @bind
   protected _onTransitionEnd(e?: TransitionEvent) {
     if (!e || e.propertyName === 'max-height') {
+      // TODO: state is not 'safe' as we can not be sure in caller
       this.style.removeProperty('max-height');
-      // TODO: rename
-      this.$$fire('transitionend', {
-        detail: {open: this.open}
-      });
+      // TODO: move to afterAnimate!
+      this.$$fire(this.open ? 'after:show' : 'after:hide');
     }
   }
 
@@ -93,6 +92,7 @@ export class ESLPanel extends ESLBasePopup {
   }
 
   protected afterAnimate(params: PanelActionParams) {
+    // FIXME: that is not working!!!
     params.noCollapse && this.style.removeProperty('max-height');
     CSSUtil.removeCls(this, this.animateClass);
     CSSUtil.removeCls(this, this.postAnimateClass);

--- a/src/modules/esl-panel/core/esl-panel.ts
+++ b/src/modules/esl-panel/core/esl-panel.ts
@@ -15,7 +15,6 @@ export interface PanelActionParams extends PopupActionParams {
 @ExportNs('Panel')
 export class ESLPanel extends ESLBasePopup {
   public static is = 'esl-panel';
-  public static eventNs = 'esl:panel';
 
   @attr({defaultValue: 'open'}) public activeClass: string;
   @attr({defaultValue: 'animate'}) public animateClass: string;
@@ -72,7 +71,8 @@ export class ESLPanel extends ESLBasePopup {
   protected _onTransitionEnd(e?: TransitionEvent) {
     if (!e || e.propertyName === 'max-height') {
       this.style.removeProperty('max-height');
-      this.$$fireNs('transitionend', {
+      // TODO: rename
+      this.$$fire('transitionend', {
         detail: {open: this.open}
       });
     }

--- a/src/modules/esl-popup/core/esl-popup.ts
+++ b/src/modules/esl-popup/core/esl-popup.ts
@@ -6,7 +6,6 @@ import {ScrollStrategy, ScrollUtility} from '../../esl-utils/dom/scroll';
 @ExportNs('Popup')
 export class ESLPopup extends ESLBasePopup {
   public static is = 'esl-popup';
-  public static eventNs = 'esl:popup';
 
   @attr({defaultValue: null}) public disableScroll: ScrollStrategy;
 

--- a/src/modules/esl-scrollable-tabs/core/esl-scrollable-tabs.ts
+++ b/src/modules/esl-scrollable-tabs/core/esl-scrollable-tabs.ts
@@ -24,6 +24,7 @@ export class ESLScrollableTabs extends ESLTabsContainer {
     this.addEventListener('click', this._onClick, false);
     this.$list?.addEventListener('scroll', this._onScroll, {passive: true});
     this.addEventListener('focusin', this._onFocus);
+    this.addEventListener('change:active', this._onTriggerStateChange);
     window.addEventListener('resize', this.onResize);
   }
 
@@ -32,6 +33,7 @@ export class ESLScrollableTabs extends ESLTabsContainer {
     this.removeEventListener('click', this._onClick, false);
     this.$list?.removeEventListener('scroll', this._onScroll);
     this.removeEventListener('focusin', this._onFocus);
+    this.removeEventListener('change:active', this._onTriggerStateChange);
     window.removeEventListener('resize', this.onResize);
   }
 
@@ -116,7 +118,6 @@ export class ESLScrollableTabs extends ESLTabsContainer {
 
   @bind
   protected _onTriggerStateChange(event: CustomEvent) {
-    super._onTriggerStateChange(event);
     this.deferredFitToViewport(this.current() as ESLTab);
   }
 

--- a/src/modules/esl-scrollable-tabs/core/esl-scrollable-tabs.ts
+++ b/src/modules/esl-scrollable-tabs/core/esl-scrollable-tabs.ts
@@ -9,7 +9,6 @@ import {ESLTab, ESLTabsContainer} from '../../esl-tab/core';
 @ExportNs('ScrollableTabs')
 export class ESLScrollableTabs extends ESLTabsContainer {
   public static is = 'esl-scrollable-tabs';
-  public static eventNs = 'esl:sc-tabs';
 
   @attr({defaultValue: '.esl-tab-list'}) public tabList: string;
 

--- a/src/modules/esl-tab/core/esl-tab.ts
+++ b/src/modules/esl-tab/core/esl-tab.ts
@@ -4,7 +4,6 @@ import ESLTrigger from '../../esl-trigger/core/esl-trigger';
 @ExportNs('Tab')
 export class ESLTab extends ESLTrigger {
   public static is = 'esl-tab';
-  public static eventNs = 'esl:tab';
 
   public updateA11y() {
     const target = this.$a11yTarget;

--- a/src/modules/esl-tab/core/esl-tabs-container.ts
+++ b/src/modules/esl-tab/core/esl-tabs-container.ts
@@ -2,7 +2,6 @@ import {ESLTriggersContainer, GroupTarget} from '../../esl-trigger/core/esl-trig
 import {ExportNs} from '../../esl-utils/environment/export-ns';
 import ESLTab from './esl-tab';
 import ESLTrigger from '../../esl-trigger/core/esl-trigger';
-import {bind} from '../../esl-utils/decorators/bind';
 import {attr} from '../../esl-base-element/decorators/attr';
 
 @ExportNs('TabsContainer')
@@ -10,16 +9,6 @@ export class ESLTabsContainer extends ESLTriggersContainer {
   public static is = 'esl-tabs-container';
 
   @attr({defaultValue: '.esl-tab-list'}) public tabList: string;
-
-  protected bindEvents() {
-    super.bindEvents();
-    this.addEventListener('activestatechange', this._onTriggerStateChange);
-  }
-
-  protected unbindEvents() {
-    super.unbindEvents();
-    this.removeEventListener('activestatechange', this._onTriggerStateChange);
-  }
 
   get $triggers(): ESLTab[] {
     const els = this.querySelectorAll(ESLTab.is);
@@ -32,19 +21,6 @@ export class ESLTabsContainer extends ESLTriggersContainer {
     const targetEl = this[target](from);
     if (!targetEl) return;
     targetEl.click();
-  }
-
-  protected updateA11y(trigger: ESLTab) {
-    const target = trigger.$a11yTarget || trigger;
-    target.setAttribute('aria-selected', String(trigger.active));
-    target.setAttribute('tabindex', trigger.active ? '0' : '-1');
-  }
-
-  @bind
-  protected _onTriggerStateChange(event: CustomEvent) {
-    const trigger = event.target;
-    if (!(trigger instanceof ESLTab)) return;
-    this.updateA11y(trigger);
   }
 }
 

--- a/src/modules/esl-tab/core/esl-tabs-container.ts
+++ b/src/modules/esl-tab/core/esl-tabs-container.ts
@@ -8,18 +8,17 @@ import {attr} from '../../esl-base-element/decorators/attr';
 @ExportNs('TabsContainer')
 export class ESLTabsContainer extends ESLTriggersContainer {
   public static is = 'esl-tabs-container';
-  public static eventNs = 'esl:tabs-container';
 
   @attr({defaultValue: '.esl-tab-list'}) public tabList: string;
 
   protected bindEvents() {
     super.bindEvents();
-    this.addEventListener(`${ESLTab.eventNs}:statechange`, this._onTriggerStateChange);
+    this.addEventListener('activestatechange', this._onTriggerStateChange);
   }
 
   protected unbindEvents() {
     super.unbindEvents();
-    this.removeEventListener(`${ESLTab.eventNs}:statechange`, this._onTriggerStateChange);
+    this.removeEventListener('activestatechange', this._onTriggerStateChange);
   }
 
   get $triggers(): ESLTab[] {
@@ -43,7 +42,8 @@ export class ESLTabsContainer extends ESLTriggersContainer {
 
   @bind
   protected _onTriggerStateChange(event: CustomEvent) {
-    const trigger = event.target as ESLTab;
+    const trigger = event.target;
+    if (!(trigger instanceof ESLTab)) return;
     this.updateA11y(trigger);
   }
 }

--- a/src/modules/esl-trigger/core/esl-trigger.ts
+++ b/src/modules/esl-trigger/core/esl-trigger.ts
@@ -108,7 +108,8 @@ export class ESLTrigger extends ESLBaseElement {
       this.attachEventListener(this.hideEvent, this._onHideEvent);
     }
     const popupClass = this._popup.constructor as typeof ESLBasePopup;
-    this.popup.addEventListener(`${popupClass.eventNs}:statechange`, this._onPopupStateChange);
+    this.popup.addEventListener(`${popupClass.eventNs}:show`, this._onPopupStateChange);
+    this.popup.addEventListener(`${popupClass.eventNs}:hide`, this._onPopupStateChange);
 
     this.addEventListener('keydown', this._onKeydown);
   }
@@ -116,8 +117,11 @@ export class ESLTrigger extends ESLBaseElement {
   protected unbindEvents() {
     (this.__unsubscribers || []).forEach((off) => off());
     if (!this.popup) return;
+
     const popupClass = this._popup.constructor as typeof ESLBasePopup;
-    this.popup.removeEventListener(`${popupClass.eventNs}:statechange`, this._onPopupStateChange);
+    this.popup.removeEventListener(`${popupClass.eventNs}:show`, this._onPopupStateChange);
+    this.popup.removeEventListener(`${popupClass.eventNs}:hide`, this._onPopupStateChange);
+
     this.removeEventListener('keydown', this._onKeydown);
   }
 
@@ -156,9 +160,7 @@ export class ESLTrigger extends ESLBaseElement {
     const clsTarget = TraversingQuery.first(this.activeClassTarget, this) as HTMLElement;
     clsTarget && CSSUtil.toggleClsTo(clsTarget, this.activeClass, this.active);
     this.updateA11y();
-    this.$$fireNs('statechange', {
-      bubbles: true
-    });
+    this.$$fireNs('statechange');
   }
 
   protected get showDelayValue(): number | undefined {

--- a/src/modules/esl-trigger/core/esl-trigger.ts
+++ b/src/modules/esl-trigger/core/esl-trigger.ts
@@ -159,7 +159,7 @@ export class ESLTrigger extends ESLBaseElement {
     const clsTarget = TraversingQuery.first(this.activeClassTarget, this) as HTMLElement;
     clsTarget && CSSUtil.toggleClsTo(clsTarget, this.activeClass, this.active);
     this.updateA11y();
-    this.$$fire('activestatechange');
+    this.$$fire('change:active');
   }
 
   protected get showDelayValue(): number | undefined {

--- a/src/modules/esl-trigger/core/esl-trigger.ts
+++ b/src/modules/esl-trigger/core/esl-trigger.ts
@@ -13,7 +13,6 @@ import type {NoopFnSignature} from '../../esl-utils/misc/functions';
 @ExportNs('Trigger')
 export class ESLTrigger extends ESLBaseElement {
   public static is = 'esl-trigger';
-  public static eventNs = 'esl:trigger';
 
   static get observedAttributes() {
     return ['target', 'event', 'mode', 'active'];
@@ -108,8 +107,8 @@ export class ESLTrigger extends ESLBaseElement {
       this.attachEventListener(this.hideEvent, this._onHideEvent);
     }
     const popupClass = this._popup.constructor as typeof ESLBasePopup;
-    this.popup.addEventListener(`${popupClass.eventNs}:show`, this._onPopupStateChange);
-    this.popup.addEventListener(`${popupClass.eventNs}:hide`, this._onPopupStateChange);
+    this.popup.addEventListener('show', this._onPopupStateChange);
+    this.popup.addEventListener('hide', this._onPopupStateChange);
 
     this.addEventListener('keydown', this._onKeydown);
   }
@@ -119,8 +118,8 @@ export class ESLTrigger extends ESLBaseElement {
     if (!this.popup) return;
 
     const popupClass = this._popup.constructor as typeof ESLBasePopup;
-    this.popup.removeEventListener(`${popupClass.eventNs}:show`, this._onPopupStateChange);
-    this.popup.removeEventListener(`${popupClass.eventNs}:hide`, this._onPopupStateChange);
+    this.popup.removeEventListener('show', this._onPopupStateChange);
+    this.popup.removeEventListener('hide', this._onPopupStateChange);
 
     this.removeEventListener('keydown', this._onKeydown);
   }
@@ -160,7 +159,7 @@ export class ESLTrigger extends ESLBaseElement {
     const clsTarget = TraversingQuery.first(this.activeClassTarget, this) as HTMLElement;
     clsTarget && CSSUtil.toggleClsTo(clsTarget, this.activeClass, this.active);
     this.updateA11y();
-    this.$$fireNs('statechange');
+    this.$$fire('activestatechange');
   }
 
   protected get showDelayValue(): number | undefined {

--- a/test-server/views/pages/esl-accordion.html
+++ b/test-server/views/pages/esl-accordion.html
@@ -23,13 +23,11 @@ title: ESL Accordion <span class="badge badge-warning">Beta</span>
                         </button>
                     </h5>
                 </esl-trigger>
-                <div>
-                    <esl-panel class="clps" group="accordion-group-2" default-params="{hideDelay: 100}">
+                <esl-panel class="clps" group="accordion-group-2" default-params="{hideDelay: 100}">
                         <div class="card-body">
                             <p>Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf moon officia aute, non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod. Brunch 3 wolf moon tempor, sunt aliqua put a bird on it squid single-origin coffee nulla assumenda shoreditch et. Nihil anim keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente ea proident. Ad vegan excepteur butcher vice lomo. Leggings occaecat craft beer farm-to-table, raw denim aesthetic synth nesciunt you probably haven't heard of them accusamus labore sustainable VHS.</p>
                         </div>
-                    </esl-panel>
-                </div>
+                </esl-panel>
             </div>
             <div class="card">
                 <esl-trigger class="card-header" target="::next" event="hover" hide-delay="250">


### PR DESCRIPTION
BREAKING CHANGE:
- `ESLBasePopup` statechange events replaced with a separate `(before:)show/hide`
- `ESLBaseElement` no longer contains eventNs and $$fireNs methods
- Whole popups based component system no longer use event namespaces
- `transitionend` event of ESLPanel replaced with `after:show`/`after:hide`
- `statechange` event of ESLTrigger replaced with `change:active`