### PR TITLE
feat: override decorator

### DIFF
--- a/src/modules/esl-base-element/README.md
+++ b/src/modules/esl-base-element/README.md
@@ -10,3 +10,6 @@ Provides the ESLBaseElement - base class for custom element declaration, and a s
  - `@attr` - to map string type property to HTML attribute.
  - `@boolAttr` - to map boolean property to HTML boolean (marker) attribute state.
  - `@jsonAttr` - to map object property to HTML attribute using JSON format to serialize / deserialize value.
+
+
+ - `@override` - to override property that declared trough the property accessors in a parent class 

--- a/src/modules/esl-base-element/core.ts
+++ b/src/modules/esl-base-element/core.ts
@@ -3,3 +3,4 @@ export * from './core/esl-base-element';
 export * from './decorators/attr';
 export * from './decorators/bool-attr';
 export * from './decorators/json-attr';
+export * from './decorators/override';

--- a/src/modules/esl-base-element/decorators/override.ts
+++ b/src/modules/esl-base-element/decorators/override.ts
@@ -1,0 +1,16 @@
+/**
+ * `@override` is auxiliary decorator to override field that decorated in the parent class.
+ *
+ *  Typically used to override {@link attr}, {@link boolAttr}, etc
+ *
+ *  @param [value] - initial property value
+ *  @param [readonly] - make a non writable constant
+ */
+export function override(value: any = undefined, readonly = false) {
+  return function (obj: any, name: string): void {
+    if (Object.hasOwnProperty.call(obj, name)) {
+      throw new TypeError('Can\'t override own property');
+    }
+    Object.defineProperty(obj, name, {value, enumerable: true, writable: !readonly});
+  };
+}

--- a/src/modules/esl-base-element/test/override.test.ts
+++ b/src/modules/esl-base-element/test/override.test.ts
@@ -1,0 +1,141 @@
+import '../../../polyfills/es5-target-shim';
+import {ESLBaseElement, attr, override, boolAttr, jsonAttr} from '../core';
+
+describe('Decorator: override', () => {
+  class TestBaseElement extends ESLBaseElement {
+    @attr()
+    public field: string;
+    @boolAttr()
+    public field2: boolean;
+    @jsonAttr()
+    public field3: {a: number};
+    @attr()
+    public field4?: string;
+    @attr({readonly: true})
+    public readonlyField: string;
+  }
+
+  describe('Overriding @attr', () => {
+    class TestElement extends TestBaseElement {
+      @override('test')
+      public field: string;
+      @override()
+      public field4?: string;
+      @override('test')
+      public readonlyField: string;
+    }
+    customElements.define('attr-override-1', TestElement);
+
+    test('should override simple @attr decorator', () => {
+      const el = new TestElement();
+      expect(el.field).toBe('test');
+    });
+    test('should override readonly @attr decorator', () => {
+      const el = new TestElement();
+      expect(el.readonlyField).toBe('test');
+    });
+    test('override should be writeable', () => {
+      const el = new TestElement();
+      el.field = el.readonlyField = 'hi';
+      expect(el.field).toBe('hi');
+      expect(el.readonlyField).toBe('hi');
+    });
+    test('original decorator should not be executed', () => {
+      const el = new TestElement();
+      el.field = 'hi';
+      expect(el.getAttribute('field')).toBe(null);
+    });
+
+    test('should have undefined as a default', () => {
+      const el = new TestElement();
+      expect('field4' in el).toBe(true);
+      expect(el.field4).toBe(undefined);
+    });
+  });
+
+  describe('Overriding @boolAttr', () => {
+    class TestElement extends TestBaseElement {
+      @override(true)
+      public field2: boolean;
+    }
+    customElements.define('bool-attr-override-1', TestElement);
+
+    test('should override simple @boolAttr decorator', () => {
+      const el = new TestElement();
+      expect(el.field2).toBe(true);
+    });
+    test('override should be writeable', () => {
+      const el = new TestElement();
+      el.field2 = false;
+      expect(el.field2).toBe(false);
+    });
+    test('original decorator should not be executed', () => {
+      const el = new TestElement();
+      expect(el.getAttribute('field2')).toBe(null);
+    });
+  });
+
+  describe('Overriding @jsonAttr', () => {
+    class TestElement extends TestBaseElement {
+      @override({a: 2})
+      public field3: {a: number};
+    }
+    customElements.define('json-attr-override-1', TestElement);
+
+    test('should override simple @jsonAttr decorator', () => {
+      const el = new TestElement();
+      expect(el.field3).toEqual({a: 2});
+    });
+    test('override should be writeable', () => {
+      const el = new TestElement();
+      el.field3 = {a: 4};
+      expect(el.field3).toEqual({a: 4});
+    });
+    test('original decorator should not be executed', () => {
+      const el = new TestElement();
+      expect(el.getAttribute('field3')).toBe(null);
+    });
+  });
+
+  describe('Overriding @attr with readonly decorator', () => {
+    class TestElement extends TestBaseElement {
+      @override('test', true)
+      public field: string;
+    }
+    customElements.define('readonly-attr-override-1', TestElement);
+
+    test('should override simple @attr decorator', () => {
+      const el = new TestElement();
+      expect(el.field).toBe('test');
+    });
+    test('override should be writeable', () => {
+      const el = new TestElement();
+      expect(() => el.field ='hi').toThrowError();
+      expect(el.field).toBe('test');
+    });
+  });
+
+  describe('Overridden property can be defined through ES initial value ', () => {
+    class TestElement extends TestBaseElement {
+      @override()
+      public field: string = '123';
+    }
+    customElements.define('es-initial-attr-override-1', TestElement);
+
+    test('should override simple @attr decorator', () => {
+      const el = new TestElement();
+      expect(el.field).toBe('123');
+    });
+  });
+
+  test('Overriding own property produce error', () => {
+    expect(() => {
+      class TestElement extends ESLBaseElement {
+        @override('')
+        @attr()
+        public field: string;
+      }
+      new TestElement();
+    }).toThrowError(/own property/);
+  });
+});

--- a/src/modules/esl-forms/esl-select/core/esl-select-dropdown.ts
+++ b/src/modules/esl-forms/esl-select/core/esl-select-dropdown.ts
@@ -5,6 +5,7 @@ import {rafDecorator} from '../../../esl-utils/async/raf';
 import {ESLSelectList} from '../../esl-select-list/core';
 
 import type {ESLSelect} from './esl-select';
+import {override} from '../../../esl-base-element/decorators/override';
 
 /**
  * ESLSelectDropdown component
@@ -28,13 +29,10 @@ export class ESLSelectDropdown extends ESLToggleable {
   protected _disposeTimeout: number;
   protected _deferredUpdatePosition = rafDecorator(() => this.updatePosition());
 
-  // TODO: update defaults + override decorator
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  get closeOnEsc() { return true; }
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  get closeOnOutsideAction() { return true; }
+  @override()
+  public closeOnEsc = true;
+  @override()
+  public closeOnOutsideAction = true;
 
   constructor() {
     super();


### PR DESCRIPTION
Dear ESL Contributors and @exadel-inc/esl-core-team, here is the feature proposal to resolve the issue with the ugly override way for properties that are decorated in the parent class, e.g. :
```
class Parent extends ESLBaseElement{
    @attr
    public param: string;
}

class Child extends Parent {
    public param: string = 'some fixed value'; // Is not working correctly as it calls the accesor of parent class
}
```

There is a list of open questions that currently are under discussion:
 - Is the `override` decorator is part of esl-base-element (according to primary usecase) or it should be moved to esl-utils?
 - Do we need to move and rename `@override(.., true /*read-only*/)` as a separate decorator to have a simplified way to make just a local field `@override field: string;`?
 - Do we need to make a writable: false property for a read-only case: 
   1) `writable: false` -> property can not be redefined in the same object (prototype) at all, setting of a value leads to an Error
   2) `writable: true` (using `get: () => value` instead) -> property can be redefined, setting of a value is simply ignored 

Feel free to share your thoughts in the current PR conversation