### PR TITLE
fix(esl-image): svg loading check update

### DIFF
--- a/src/modules/esl-image/README.md
+++ b/src/modules/esl-image/README.md
@@ -1,6 +1,6 @@
 # [ESL](../../../README.md) Image
 
-Version: *1.2.0*
+Version: *1.2.1*
 
 Authors: *Alexey Stsefanovich (ala'n)*, *Yuliya Adamskaya*
 

--- a/src/modules/esl-image/core/esl-image.ts
+++ b/src/modules/esl-image/core/esl-image.ts
@@ -183,11 +183,8 @@ export class ESLImage extends ESLBaseElement {
         this.syncImage();
       }
 
-      if (this._shadowImg.complete && this._shadowImg.naturalHeight > 0) {
-        this._onLoad();
-      }
-      if (this._shadowImg.complete && this._shadowImg.naturalHeight <= 0) {
-        this._onError();
+      if (this._shadowImg.complete) {
+        this._shadowImgError ? this._onError() : this._onLoad();
       }
     }
 
@@ -261,6 +258,12 @@ export class ESLImage extends ESLBaseElement {
       this._shadowImageElement.onerror = this._onError;
     }
     return this._shadowImageElement;
+  }
+
+  protected get _shadowImgError() {
+    if (!this._shadowImg.complete) return false;
+    if (this._shadowImg.src.substr(-4) === '.svg') return false;
+    return this._shadowImg.naturalHeight <= 0;
   }
 
   @bind


### PR DESCRIPTION
Not sure that we need to do that, but it looks like that's the only possible way to check SVGs state, as they have naturalWIdth = naturalHeight = 0 in Gecko in case the width and height are not specified in SVG content.