### PR TITLE
fix: activator should be available after hide

### DIFF
--- a/src/modules/esl-toggleable/core/esl-toggleable.ts
+++ b/src/modules/esl-toggleable/core/esl-toggleable.ts
@@ -191,7 +191,6 @@ export class ESLToggleable extends ESLBaseElement {
     if (!params.silent && !this.$$fire('before:hide',{detail: {params}})) return;
     this.open = false;
     this.onHide(params);
-    this.activator = null;
     if (!params.silent) this.$$fire('hide', {detail: {params}, cancelable: false});
   }
 
@@ -227,7 +226,7 @@ export class ESLToggleable extends ESLBaseElement {
   }
 
   /** Last component that has activated the element. Uses {@link ToggleableActionParams.activator}*/
-  public get activator() {
+  public get activator(): HTMLElement | null | undefined {
     return activators.get(this);
   }
   public set activator(el: HTMLElement | null | undefined) {


### PR DESCRIPTION
Most likely will be revised soon, but it sounds like auto-clear in the low-level method is not good idea (at least), 