### PR TITLE
refactor: esl-media-query cleanup for API and usages

### DIFF
--- a/src/modules/esl-image/core/esl-image-strategies.ts
+++ b/src/modules/esl-image/core/esl-image-strategies.ts
@@ -5,7 +5,7 @@ import {ESLImage} from './esl-image';
  */
 export interface ESLImageRenderStrategy {
   /** Apply image from shadow loader */
-  apply: (img: ESLImage, shadowImg: ShadowImageElement) => void;
+  apply: (img: ESLImage, shadowImg: HTMLImageElement) => void;
   /** Clean strategy specific changes from ESLImage */
   clear: (img: ESLImage) => void;
 }
@@ -15,13 +15,6 @@ export interface ESLImageRenderStrategy {
  */
 export interface ESLImageStrategyMap {
   [mode: string]: ESLImageRenderStrategy;
-}
-
-/**
- * Mixed image element that used as shadow loader for ESLImage
- */
-export interface ShadowImageElement extends HTMLImageElement {
-  dpr?: number
 }
 
 export const STRATEGIES: ESLImageStrategyMap = {
@@ -62,7 +55,7 @@ export const STRATEGIES: ESLImageStrategyMap = {
     apply(img, shadowImg) {
       const innerImg = img.attachInnerImage();
       innerImg.src = shadowImg.src;
-      innerImg.width = shadowImg.width / (shadowImg.dpr || 1);
+      innerImg.width = shadowImg.width / window.devicePixelRatio;
     },
     clear(img) {
       img.removeInnerImage();

--- a/src/modules/esl-image/core/esl-image.ts
+++ b/src/modules/esl-image/core/esl-image.ts
@@ -9,7 +9,7 @@ import {TraversingQuery} from '../../esl-traversing-query/core/esl-traversing-qu
 import {getIObserver} from './esl-image-iobserver';
 import {STRATEGIES} from './esl-image-strategies';
 
-import type {ESLImageRenderStrategy, ShadowImageElement} from './esl-image-strategies';
+import type {ESLImageRenderStrategy} from './esl-image-strategies';
 
 type LoadState = 'error' | 'loaded' | 'ready';
 const isLoadState = (state: string): state is LoadState => ['error', 'loaded', 'ready'].includes(state);
@@ -61,7 +61,7 @@ export class ESLImage extends ESLBaseElement {
   private _srcRules: ESLMediaRuleList<string>;
   private _currentSrc: string;
   private _detachLazyTrigger: () => void;
-  private _shadowImageElement: ShadowImageElement;
+  private _shadowImageElement: HTMLImageElement;
 
   protected connectedCallback() {
     super.connectedCallback();
@@ -179,7 +179,6 @@ export class ESLImage extends ESLBaseElement {
     if (this._currentSrc !== src || !this.ready || force) {
       this._currentSrc = src;
       this._shadowImg.src = src;
-      this._shadowImg.dpr = dpr;
 
       if (this.refreshOnUpdate || !this.ready) {
         this.syncImage();

--- a/src/modules/esl-image/core/esl-image.ts
+++ b/src/modules/esl-image/core/esl-image.ts
@@ -172,9 +172,7 @@ export class ESLImage extends ESLBaseElement {
   protected update(force: boolean = false) {
     if (!this.canUpdate) return;
 
-    const rule = this.srcRules.active;
-    const src = this.getPath(rule.payload);
-    const dpr = rule.dpr;
+    const src = this.getPath(this.srcRules.activeValue);
 
     if (this._currentSrc !== src || !this.ready || force) {
       this._currentSrc = src;

--- a/src/modules/esl-media-query/core/esl-media-query.ts
+++ b/src/modules/esl-media-query/core/esl-media-query.ts
@@ -30,6 +30,7 @@ export class ESLMediaQuery {
   }
 
   static buildDprQuery(dpr: number) {
+    if (ESLMediaQuery.ignoreBotsDpr && DeviceDetector.isBot && dpr !== 1) return ESLMediaQuery.NOT_ALL;
     if (DeviceDetector.isSafari) return `(-webkit-min-device-pixel-ratio: ${dpr})`;
     return `(min-resolution: ${(96 * dpr).toFixed(1)}dpi)`;
   }
@@ -42,7 +43,6 @@ export class ESLMediaQuery {
    */
   static ignoreBotsDpr = false;
 
-  private _dpr: number;
   private _mobileOnly: boolean | undefined;
   private readonly _query: MediaQueryList;
 
@@ -51,14 +51,10 @@ export class ESLMediaQuery {
     query = ESLMediaBreakpoints.apply(query);
 
     // Applying dpr shortcut
-    this._dpr = 1;
-    query = query.replace(/@(\d(\.\d)?)x/g, (match, ratio) => {
-      this._dpr = +ratio;
-      if (ESLMediaQuery.ignoreBotsDpr && DeviceDetector.isBot && this._dpr !== 1) {
-        return ESLMediaQuery.NOT_ALL;
-      }
-      return ESLMediaQuery.buildDprQuery(ratio);
-    });
+    query = query.replace(
+      /@(\d(\.\d)?)x/g,
+      (match, ratio) => ESLMediaQuery.buildDprQuery(+ratio)
+    );
 
     // Applying dpr shortcut for device detection
     query = query.replace(/(and )?(@MOBILE|@DESKTOP)( and)?/ig, (match, pre, type, post) => {
@@ -80,11 +76,6 @@ export class ESLMediaQuery {
   /** Accepts only desktop devices */
   public get isDesktopOnly(): boolean {
     return this._mobileOnly === false;
-  }
-
-  /** Current query dpr */
-  public get dpr(): number {
-    return this._dpr;
   }
 
   /** inner MediaQueryList instance */

--- a/src/modules/esl-media-query/core/esl-media-query.ts
+++ b/src/modules/esl-media-query/core/esl-media-query.ts
@@ -43,7 +43,6 @@ export class ESLMediaQuery {
    */
   static ignoreBotsDpr = false;
 
-  private _mobileOnly: boolean | undefined;
   private readonly _query: MediaQueryList;
 
   constructor(query: string) {
@@ -58,24 +57,13 @@ export class ESLMediaQuery {
 
     // Applying dpr shortcut for device detection
     query = query.replace(/(and )?(@MOBILE|@DESKTOP)( and)?/ig, (match, pre, type, post) => {
-      this._mobileOnly = (type.toUpperCase() === '@MOBILE');
-      if (DeviceDetector.isMobile !== this._mobileOnly) {
+      if (DeviceDetector.isMobile !== (type.toUpperCase() === '@MOBILE')) {
         return ESLMediaQuery.NOT_ALL; // whole query became invalid
       }
       return pre && post ? 'and' : '';
     });
 
     this._query = ESLMediaQuery.matchMediaCached(query.trim() || ESLMediaQuery.ALL);
-  }
-
-  /** Accepts only mobile devices */
-  public get isMobileOnly(): boolean {
-    return this._mobileOnly === true;
-  }
-
-  /** Accepts only desktop devices */
-  public get isDesktopOnly(): boolean {
-    return this._mobileOnly === false;
   }
 
   /** inner MediaQueryList instance */

--- a/src/modules/esl-media-query/test/esl-media-query.test.ts
+++ b/src/modules/esl-media-query/test/esl-media-query.test.ts
@@ -109,18 +109,6 @@ describe('ESLMediaQuery tests', () => {
   })
 
   describe('API tests', () => {
-    test('Mobile/Desktop getters', () => {
-      const mqMob = new ESLMediaQuery('@Mobile');
-      const mqDesk = new ESLMediaQuery('@Desktop');
-
-      expect(mqMob.isMobileOnly).toBeTruthy();
-      expect(mqMob.isDesktopOnly).toBeFalsy();
-
-      expect(mqDesk.isDesktopOnly).toBeTruthy();
-      expect(mqDesk.isMobileOnly).toBeFalsy();
-
-    });
-
     test('Listeners', () => {
       const mq = new ESLMediaQuery('@xs');
       const listener = jest.fn();

--- a/src/modules/esl-media-query/test/esl-media-query.test.ts
+++ b/src/modules/esl-media-query/test/esl-media-query.test.ts
@@ -109,12 +109,6 @@ describe('ESLMediaQuery tests', () => {
   })
 
   describe('API tests', () => {
-    test('DPR getters', () => {
-      expect(new ESLMediaQuery('@sm').dpr).toBe(1);
-      expect(new ESLMediaQuery('@2x').dpr).toBe(2);
-      expect(new ESLMediaQuery('@2.3x').dpr).toBe(2.3);
-    });
-
     test('Mobile/Desktop getters', () => {
       const mqMob = new ESLMediaQuery('@Mobile');
       const mqDesk = new ESLMediaQuery('@Desktop');


### PR DESCRIPTION
BREAKING CHANGE: 
ESLMediaQuery API no longer provide meta information like DPR or type of expected device

Preparation for #232 updates.