### PR TITLE
feat: light memoize decorator

### DIFF
--- a/src/modules/esl-utils/decorators/memoize.ts
+++ b/src/modules/esl-utils/decorators/memoize.ts
@@ -1,8 +1,8 @@
-import {getPropertyDescriptor} from '../misc/object';
 import {defaultArgsHashFn, memoizeFn} from '../misc/memoize';
+import {isPrototype, getPropertyDescriptor} from '../misc/object';
+
 import type {MemoHashFn} from '../misc/memoize';
 import type {MethodTypedDecorator} from '../misc/functions';
-
 
 export function memoize(): MethodDecorator;
 export function memoize<H extends MemoHashFn>(hashFn: H): MethodTypedDecorator<(...args: Parameters<H>) => any>;
@@ -12,32 +12,46 @@ export function memoize<H extends MemoHashFn>(hashFn: H): MethodTypedDecorator<(
  */
 export function memoize(hashFn: MemoHashFn = defaultArgsHashFn) {
   return function (target: any, prop: string, descriptor: TypedPropertyDescriptor<any>) {
-    const isPrototype = Object.hasOwnProperty.call(target, 'constructor');
-    if (descriptor && typeof descriptor.value === 'function') {
-      descriptor.value = isPrototype ?
-        memoizeMember(descriptor.value, prop, false, hashFn) :
-        memoizeFn(descriptor.value, hashFn);
-    } else if (descriptor && typeof descriptor.get === 'function') {
-      descriptor.get = isPrototype ?
-        memoizeMember(descriptor.get, prop, true, hashFn) :
-        memoizeFn(descriptor.get, hashFn);
-    } else {
+    if (!descriptor || typeof (descriptor.value || descriptor.get) !== 'function') {
       throw new TypeError('Only get accessors or class methods can be decorated via @memoize');
+    }
+
+    if (isPrototype(target)) {
+      // Object members
+      (typeof descriptor.get === 'function') && (descriptor.get = memoizeGetter(descriptor.get, prop));
+      (typeof descriptor.value === 'function') && (descriptor.value = memoizeMethod(descriptor.value, prop, hashFn));
+    } else {
+      // Static members
+      (typeof descriptor.get === 'function') && (descriptor.get = memoizeFn(descriptor.get));
+      (typeof descriptor.value === 'function') && (descriptor.value = memoizeFn(descriptor.value, hashFn));
     }
   };
 }
 
 // Lock storage to prevent cache logic for some key
 const locks = new WeakMap();
+const defineOwnKeySafe = (obj: any, prop: string, value: any) => {
+  locks.set(obj, prop); // IE try to get key with the prototype instance call, so we lock it
+  Object.defineProperty(obj, prop, {value, writable: true, configurable: true});
+  locks.delete(obj); // Free property key
+};
 
-/** Cache memo function in the current context on call */
-function memoizeMember(originalMethod: any, prop: string, isGetter: boolean, hashFn: MemoHashFn) {
+/** Cache getter result as an object ovn property */
+function memoizeGetter(originalMethod: any, prop: string) {
+  return function (this: any, ...args: any[]): any {
+    if (locks.get(this) === prop) return originalMethod;
+    const value = originalMethod.call(this);
+    defineOwnKeySafe(this, prop, value);
+    return value;
+  };
+}
+
+/** Cache method memo function in the current context on call */
+function memoizeMethod(originalMethod: any, prop: string, hashFn: MemoHashFn) {
   return function (this: any, ...args: any[]): any {
     if (locks.get(this) === prop) return originalMethod;
     const memo = memoizeFn(originalMethod, hashFn);
-    locks.set(this, prop); // IE try to get key with the prototype instance call, so we lock it
-    Object.defineProperty(this, prop, isGetter ? {get: memo} : {value: memo});
-    locks.delete(this); // Free property key
+    defineOwnKeySafe(this, prop, memo);
     return memo.apply(this, args);
   };
 }
@@ -47,9 +61,9 @@ function memoizeMember(originalMethod: any, prop: string, isGetter: boolean, has
  * Accepts not own properties.
  */
 memoize.clear = function (target: any, property: string) {
-  let clearFn = null;
   const desc = getPropertyDescriptor(target, property);
-  if (desc && typeof desc.value === 'function') clearFn = desc.value.clear;
-  if (desc && typeof desc.get === 'function') clearFn = (desc.get as any).clear;
-  (typeof clearFn === 'function') && clearFn();
+  if (!desc) return;
+  if (typeof desc.get === 'function' && typeof (desc.get as any).clear === 'function') return (desc.get as any).clear();
+  if (typeof desc.value === 'function' && typeof desc.value.clear === 'function') return desc.value.clear();
+  if (Object.hasOwnProperty.call(target, property)) delete target[property];
 };

--- a/src/modules/esl-utils/decorators/memoize.ts
+++ b/src/modules/esl-utils/decorators/memoize.ts
@@ -36,7 +36,7 @@ const defineOwnKeySafe = (obj: any, prop: string, value: any) => {
   locks.delete(obj); // Free property key
 };
 
-/** Cache getter result as an object ovn property */
+/** Cache getter result as an object own property */
 function memoizeGetter(originalMethod: any, prop: string) {
   return function (this: any, ...args: any[]): any {
     if (locks.get(this) === prop) return originalMethod;
@@ -59,6 +59,8 @@ function memoizeMethod(originalMethod: any, prop: string, hashFn: MemoHashFn) {
 /**
  * Clear memoization cache for passed target and property.
  * Accepts not own properties.
+ * Note: be sure that you targeting memoized property or function.
+ * Clear utility has no 100% check to prevent modifying incorrect (not memoized) property keys
  */
 memoize.clear = function (target: any, property: string) {
   const desc = getPropertyDescriptor(target, property);

--- a/src/modules/esl-utils/misc/object.ts
+++ b/src/modules/esl-utils/misc/object.ts
@@ -3,6 +3,8 @@ export const isObjectLike = (obj: any) => isObject(obj) || typeof obj === 'funct
 export const isPrimitive = (obj: any): obj is string | number | boolean =>
   typeof obj === 'string' || typeof obj === 'number' || typeof obj === 'boolean';
 
+export const isPrototype = (obj: any) => Object.hasOwnProperty.call(obj, 'constructor');
+
 export type CopyPredicate = (key: string, value: any) => boolean;
 
 /** Deep object compare */


### PR DESCRIPTION
Update memoize decorator inner logic to use simple value caching for members simple property so 

### current strategy is
 - Static method -> replace to memo-decorated method
 - Static getter -> replace getter function to memo-decorated
 
 - object method -> memo-decorated own property method
 - object getter -> own property computed value _(**new**)_