### PR TITLE
fix(esl-note): fix broken connection between esl-note and esl-footnotes

### DIFF
--- a/src/modules/esl-footnotes/core/esl-footnotes.less
+++ b/src/modules/esl-footnotes/core/esl-footnotes.less
@@ -25,7 +25,7 @@ esl-footnotes {
     cursor: pointer;
 
     &::before {
-      content: '[\2BC5]';
+      content: '[ ^ ]';
     }
   }
 }

--- a/src/modules/esl-footnotes/core/esl-footnotes.ts
+++ b/src/modules/esl-footnotes/core/esl-footnotes.ts
@@ -24,7 +24,7 @@ export class ESLFootnotes extends ESLBaseElement {
     super.connectedCallback();
 
     this.bindEvents();
-    EventUtils.dispatch(this, `${ESLNote.eventNs}:request`);
+    this._sendRequestToNote();
   }
 
   protected disconnectedCallback() {
@@ -101,5 +101,9 @@ export class ESLFootnotes extends ESLBaseElement {
       const note = index ? this._notes.find((el) => el.index === +index) : null;
       note?.activate();
     }
+  }
+
+  protected _sendRequestToNote() {
+    EventUtils.dispatch(this, `${ESLNote.eventNs}:request`);
   }
 }

--- a/src/modules/esl-note/core/esl-note.ts
+++ b/src/modules/esl-note/core/esl-note.ts
@@ -53,7 +53,7 @@ export class ESLNote extends ESLBaseElement {
     this._innerHTML = this.innerHTML;
     super.connectedCallback();
     this.bindEvents();
-    EventUtils.dispatch(this, `${ESLNote.eventNs}:response`);
+    this._sendResponseToFootnote();
   }
 
   @ready
@@ -96,7 +96,7 @@ export class ESLNote extends ESLBaseElement {
     this._$footnotes = null;
     this.innerHTML = this.html;
     this.tabIndex = -1;
-    EventUtils.dispatch(this, `${ESLNote.eventNs}:ready`);
+    this._sendResponseToFootnote();
   }
 
   /** Merge params to pass to the toggleable */
@@ -160,7 +160,10 @@ export class ESLNote extends ESLBaseElement {
   @bind
   protected _onFootnotesReady(e: CustomEvent) {
     if (this.linked) return;
-    EventUtils.dispatch(this, `${ESLNote.eventNs}:response`);
+    this._sendResponseToFootnote();
   }
 
+  protected _sendResponseToFootnote() {
+    EventUtils.dispatch(this, `${ESLNote.eventNs}:response`);
+  }
 }


### PR DESCRIPTION
Communication between notes and footnotes was broken during the last big PR.
This fixes the issue.
Also changed character for footnotes button "Return to note" due to its absence in fonts on some platforms.