### PR TITLE
fix(esl-footnotes): ESLNote lost tooltip text and ESLFootnotes duplicate notes and break order

### DIFF
--- a/src/modules/esl-footnotes/core/esl-footnotes-data.ts
+++ b/src/modules/esl-footnotes/core/esl-footnotes-data.ts
@@ -24,9 +24,16 @@ export function compileFootnotesGroupedList(notes: ESLNote[]): FootnotesItem[] {
   convertNotesToFootnotesList(notes).forEach(({index, text}) => {
     map.set(text, map.has(text) ? `${map.get(text)}, ${index}` : index);
   });
-  return Array.from(map)
-    .reduce(
-      (list,[text, index]) => [...list, {index, text}],
-      []
-    );
+  const groupedList: FootnotesItem[] = [];
+  map.forEach((index, text) => groupedList.push({index, text}));
+  return groupedList;
+}
+
+/* Sort notes list */
+export function sortFootnotes(notes: ESLNote[]): ESLNote[] {
+  return notes.sort((note1: ESLNote, note2: ESLNote) => {
+    const rect1 = note1.getBoundingClientRect();
+    const rect2 = note2.getBoundingClientRect();
+    return rect1.top - rect2.top || rect1.left - rect2.left;
+});
 }

--- a/src/modules/esl-footnotes/core/esl-note.ts
+++ b/src/modules/esl-footnotes/core/esl-note.ts
@@ -22,8 +22,8 @@ export class ESLNote extends ESLBaseElement {
   /** Tooltip state marker */
   @boolAttr() public tooltipShown: boolean;
 
-  /** Tooltip text */
-  @attr() public tooltipText: string;
+  /** Tooltip content */
+  @attr() public html: string;
 
   /** Click event tracking media query. Default: `all` */
   @attr({defaultValue: 'all'}) public trackClick: string;
@@ -50,14 +50,10 @@ export class ESLNote extends ESLBaseElement {
     return this._index;
   }
 
-  get html() {
-    return this.tooltipText;
-  }
-
   @ready
   protected connectedCallback() {
-    if (!this.tooltipText) {
-      this.tooltipText = this.innerHTML;
+    if (!this.html) {
+      this.html = this.innerHTML;
     }
     super.connectedCallback();
     this.bindEvents();

--- a/src/modules/esl-footnotes/core/esl-note.ts
+++ b/src/modules/esl-footnotes/core/esl-note.ts
@@ -22,6 +22,9 @@ export class ESLNote extends ESLBaseElement {
   /** Tooltip state marker */
   @boolAttr() public tooltipShown: boolean;
 
+  /** Tooltip text */
+  @attr() public tooltipText: string;
+
   /** Click event tracking media query. Default: `all` */
   @attr({defaultValue: 'all'}) public trackClick: string;
   /** Hover event tracking media query. Default: `all` */
@@ -29,7 +32,6 @@ export class ESLNote extends ESLBaseElement {
 
   protected _$footnotes: ESLFootnotes | null;
   protected _index: number;
-  protected _innerHTML: string;
 
   /** Marker to allow track hover */
   public get allowHover() {
@@ -49,22 +51,24 @@ export class ESLNote extends ESLBaseElement {
   }
 
   get html() {
-    return this._innerHTML;
+    return this.tooltipText;
   }
 
   @ready
   protected connectedCallback() {
-    this._innerHTML = this.innerHTML;
+    if (!this.tooltipText) {
+      this.tooltipText = this.innerHTML;
+    }
     super.connectedCallback();
     this.bindEvents();
     this._sendResponseToFootnote();
   }
 
-  @ready
   protected disconnectedCallback() {
     super.disconnectedCallback();
     this.unbindEvents();
     this._$footnotes?.unlinkNote(this);
+    this.restore();
   }
 
   protected attributeChangedCallback(attrName: string, oldVal: string, newVal: string) {
@@ -100,17 +104,25 @@ export class ESLNote extends ESLBaseElement {
   public link(footnotes: ESLFootnotes, index: number) {
     this.linked = true;
     this._$footnotes = footnotes;
-    this._index = index;
-    this.innerHTML = `${index}`;
+    this.setIndex(index);
     this.tabIndex = 0;
   }
 
   public unlink() {
+    this.restore();
+    this._sendResponseToFootnote();
+  }
+
+  public setIndex(index: number) {
+    this._index = index;
+    this.innerHTML = `${index}`;
+  }
+
+  protected restore() {
     this.linked = false;
     this._$footnotes = null;
     this.innerHTML = this.html;
     this.tabIndex = -1;
-    this._sendResponseToFootnote();
   }
 
   /** Merge params to pass to the toggleable */


### PR DESCRIPTION
Fixed:
- ESLNote lost tooltip text (after cloning element)
- ESLFootnotes breaks the order of notes
- ESLFootnotes duplicate notes if they were cloned