### PR TITLE
replace all instances of "sample" with "example"matching case as needed

### DIFF
--- a/pages/src/common/dropdown-menu.less
+++ b/pages/src/common/dropdown-menu.less
@@ -1,6 +1,6 @@
 // TODO: review after base styles creation
 // TODO: share with core ?
-.esl-sample-menu {
+.esl-example-menu {
   display: flex;
   width: 100%;
   height: 38px;
@@ -76,11 +76,11 @@
   }
 }
 
-.esl-sample-menu-400 {
+.esl-example-menu-400 {
   width: 300px;
   padding: 5px 10px;
 }
-.esl-sample-sub-menu {
+.esl-example-sub-menu {
   min-width: 180px;
   padding: 0 5px 2px;
 

--- a/pages/views/_includes/header.njk
+++ b/pages/views/_includes/header.njk
@@ -7,7 +7,7 @@
     {% from 'header-menu.njk' import menu with context %}
     <ul class="navbar-nav flex-grow-1 flex-column flex-md-row justify-content-end">
       <li class="nav-item hd-dropdown">
-        {{ menu ('Samples', 'samples') }}
+        {{ menu ('Examples', 'examples') }}
       </li>
       <li class="nav-item hd-dropdown">
         {{ menu ('Components', 'components') }}

--- a/pages/views/examples/accordion.njk
+++ b/pages/views/examples/accordion.njk
@@ -3,7 +3,7 @@ layout: basic
 title: Accordion
 name: Accordion
 containerCls: container
-tags: samples
+tags: examples
 ---
 {% import 'lorem.njk' as lorem %}
 

--- a/pages/views/examples/carousel.njk
+++ b/pages/views/examples/carousel.njk
@@ -2,7 +2,7 @@
 layout: basic
 title: Carousel
 name: Carousel
-tags: [samples, draft]
+tags: [examples, draft]
 ---
 
 <div class="container-fluid">

--- a/pages/views/examples/embedded-audio.njk
+++ b/pages/views/examples/embedded-audio.njk
@@ -3,7 +3,7 @@ layout: basic
 title: Embedded Audio
 name: Embedded Audio
 containerCls: container
-tags: samples
+tags: examples
 ---
 {% import 'lorem.njk' as lorem %}
 

--- a/pages/views/examples/embedded-video.njk
+++ b/pages/views/examples/embedded-video.njk
@@ -3,7 +3,7 @@ layout: basic
 title: Embedded Video
 name: Embedded Video
 containerCls: container
-tags: samples
+tags: examples
 ---
 {% import 'lorem.njk' as lorem %}
 

--- a/pages/views/examples/footnotes.njk
+++ b/pages/views/examples/footnotes.njk
@@ -3,7 +3,7 @@ layout: basic
 title: Footnotes
 name: Footnotes
 containerCls: container
-tags: [samples, draft]
+tags: [examples, draft]
 ---
 
 <section class="row">

--- a/pages/views/examples/forms-select-list.njk
+++ b/pages/views/examples/forms-select-list.njk
@@ -3,7 +3,7 @@ layout: basic
 title: Forms - Select List
 name: Select List
 containerCls: container
-tags: [samples, beta]
+tags: [examples, beta]
 ---
 
 <section class="row">

--- a/pages/views/examples/forms-select.njk
+++ b/pages/views/examples/forms-select.njk
@@ -3,7 +3,7 @@ layout: basic
 title: Forms - Select Dropdown
 name: Select Dropdown
 containerCls: container
-tags: [samples, beta]
+tags: [examples, beta]
 ---
 
 <section class="row">

--- a/pages/views/examples/image.njk
+++ b/pages/views/examples/image.njk
@@ -3,7 +3,7 @@ layout: basic
 title: Image
 name: Image
 containerCls: container
-tags: samples
+tags: examples
 ---
 {% import 'lorem.njk' as lorem %}
 

--- a/pages/views/examples/menu.njk
+++ b/pages/views/examples/menu.njk
@@ -3,7 +3,7 @@ layout: basic
 title: Menu
 name: Menu
 containerCls: container
-tags: samples
+tags: examples
 ---
 {% import 'lorem.njk' as lorem %}
 
@@ -22,7 +22,7 @@ tags: samples
   <div class="col-12">
     <h2>Simple Hover Menu: </h2>
 
-    <ul class="esl-sample-menu">
+    <ul class="esl-example-menu">
       <li class="menu-item">
         <esl-trigger class="menu-item-btn menu-item-arrow"
                      track-hover
@@ -33,7 +33,7 @@ tags: samples
                    group="esl-nav"
                    fallback-duration="400"
                    close-on-esc close-on-outside-action>
-          <ul class="esl-sample-sub-menu">
+          <ul class="esl-example-sub-menu">
             <li>1</li>
             <li>2</li>
             <li>3</li>
@@ -53,7 +53,7 @@ tags: samples
                    group="esl-nav"
                    fallback-duration="400"
                    close-on-esc close-on-outside-action>
-          <div class="esl-sample-menu-400">{{ lorem.paragraphs(1) }}</div>
+          <div class="esl-example-menu-400">{{ lorem.paragraphs(1) }}</div>
         </esl-panel>
       </li>
       <li class="menu-item">
@@ -66,7 +66,7 @@ tags: samples
                    group="esl-nav"
                    fallback-duration="400"
                    close-on-esc close-on-outside-action>
-          <ul class="esl-sample-sub-menu">
+          <ul class="esl-example-sub-menu">
             <li>1</li>
             <li>2</li>
             <li>3</li>
@@ -88,14 +88,14 @@ tags: samples
   <div class="col-12">
     <h2>Simple Menu: </h2>
 
-    <ul class="esl-sample-menu">
+    <ul class="esl-example-menu">
       <li class="menu-item">
         <esl-trigger class="menu-item-btn menu-item-arrow">Menu 1</esl-trigger>
         <esl-panel class="menu-container"
                    group="esl-nav"
                    fallback-duration="400"
                    close-on-esc close-on-outside-action>
-          <ul class="esl-sample-sub-menu">
+          <ul class="esl-example-sub-menu">
             <li>1</li>
             <li>2</li>
             <li>3</li>
@@ -111,7 +111,7 @@ tags: samples
                    group="esl-nav"
                    fallback-duration="400"
                    close-on-esc close-on-outside-action>
-          <div class="esl-sample-menu-400">{{ lorem.paragraphs(1) }}</div>
+          <div class="esl-example-menu-400">{{ lorem.paragraphs(1) }}</div>
         </esl-panel>
       </li>
       <li class="menu-item">
@@ -120,7 +120,7 @@ tags: samples
                    group="esl-nav"
                    fallback-duration="400"
                    close-on-esc close-on-outside-action>
-          <ul class="esl-sample-sub-menu">
+          <ul class="esl-example-sub-menu">
             <li>1</li>
             <li>2</li>
             <li>3</li>

--- a/pages/views/examples/notification.njk
+++ b/pages/views/examples/notification.njk
@@ -3,7 +3,7 @@ layout: basic
 title: Notification
 name: Notification
 containerCls: container
-tags: samples
+tags: examples
 ---
 {% import 'lorem.njk' as lorem %}
 

--- a/pages/views/examples/popup.njk
+++ b/pages/views/examples/popup.njk
@@ -3,7 +3,7 @@ layout: popup
 title: Popup
 name: Popup
 containerCls: container
-tags: [samples, draft]
+tags: [examples, draft]
 ---
 
 <section class="row justify-content-between">

--- a/pages/views/examples/scrollbar.njk
+++ b/pages/views/examples/scrollbar.njk
@@ -3,7 +3,7 @@ layout: basic
 title: Scrollbar
 name: Scrollbar
 containerCls: container
-tags: samples
+tags: examples
 ---
 {% import 'lorem.njk' as lorem %}
 

--- a/pages/views/examples/tabs.njk
+++ b/pages/views/examples/tabs.njk
@@ -3,7 +3,7 @@ layout: basic
 title: Tabs
 name: Tabs
 containerCls: container
-tags: samples
+tags: examples
 ---
 {% import 'lorem.njk' as lorem %}
 

--- a/pages/views/examples/toggleable.njk
+++ b/pages/views/examples/toggleable.njk
@@ -3,7 +3,7 @@ layout: basic
 title: Toggleable
 name: Toggleable
 containerCls: container
-tags: samples
+tags: examples
 ---
 {% import 'lorem.njk' as lorem %}
 

--- a/pages/views/index.njk
+++ b/pages/views/index.njk
@@ -14,9 +14,9 @@ ui_playground: github.com/exadel-inc/ui-playground
 </div>
 <hr/>
 
-<h3 id="form-components">Quick Samples</h3>
+<h3 id="form-components">Quick Examples</h3>
 <ul class="list-inline">
-  {% for item in collections.samples | sortByName %}
+  {% for item in collections.examples | sortByName %}
     <li class="list-inline-item"><h5><a href="{{ item.url | url }}">{{ item.data.name }}</a></h5></li>
   {% endfor %}
 </ul>

--- a/src/modules/esl-base-element/shape/wai-aria.shape.ts
+++ b/src/modules/esl-base-element/shape/wai-aria.shape.ts
@@ -164,7 +164,7 @@ export interface AriaAttributesShape {
 
   /**
    * Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value.
-   * A hint could be a sample value or a brief description of the expected format.
+   * A hint could be a example value or a brief description of the expected format.
    */
   'aria-placeholder'?: string;
 


### PR DESCRIPTION
# PR Details

change sample to example

## Description

All instances of "sample" found throughout the project have been changed to "example" while preserving case

## Related Issue

#520  [hammer gh-pages]: Rename 11ty tag and label from 'sample(s)' to 'example(s)'

## Motivation and Context

This change was made to resolve issue #520 

## How Has This Been Tested

I am running the site on my development box (Linux) and walked through the site to verify all changes were made.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
