### PR TITLE
chore: add commit-lint action workflow

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -1,0 +1,29 @@
+name: Lint Commit Messages
+
+on:
+  pull_request:
+
+env:
+  node-version: 14.x
+
+jobs:
+  validate:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Use Node v${{ env.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ env.node-version }}
+      - name: Install NPM Dependencies
+        run: npm ci
+      - name: Run Commit Lint
+        uses: wagoid/commitlint-github-action@v4
+        with:
+          helpURL: 'https://github.com/exadel-inc/esl/blob/main/docs/COMMIT_CONVENTION.md'
+        env:
+          NODE_PATH: ${{ github.workspace }}/node_modules


### PR DESCRIPTION
# PR Details
As an ESL maintainer, I want to be prepared when the commit messages are incorrect to use Squash Merge instead. 

## Description

Add Commit Lint GitHub action workflow to verify PR commit messages
