### PR TITLE
fix(esl-utils): scrollIntoViewAsync() method signature

### DIFF
--- a/src/modules/esl-utils/dom/scroll.ts
+++ b/src/modules/esl-utils/dom/scroll.ts
@@ -106,7 +106,7 @@ export function isScrollParent(element: Element): boolean {
  * @param element - element to be made visible to the user
  * @param options - scrollIntoView options
  */
-export function scrollIntoViewAsync(element: Element, options: ScrollIntoViewOptions): Promise<void> {
+export function scrollIntoViewAsync(element: Element, options?: boolean | ScrollIntoViewOptions | undefined): Promise<void> {
   element.scrollIntoView(options);
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
Corrects the scrollIntoViewAsync() method signature so that it exactly matches the native one.
