### PR TITLE
feat: add ability to scrollIntoView to detect when scrolling stops

### DIFF
--- a/src/modules/esl-footnotes/core/esl-note.ts
+++ b/src/modules/esl-footnotes/core/esl-note.ts
@@ -5,7 +5,7 @@ import {ready} from '../../esl-utils/decorators/ready';
 import {ESLTooltip} from '../../esl-tooltip/core';
 import {EventUtils} from '../../esl-utils/dom/events';
 import {ENTER, SPACE} from '../../esl-utils/dom/keys';
-import {scrollIntoViewAsync} from '../../esl-utils/dom/scroll';
+import {scrollIntoView} from '../../esl-utils/dom/scroll';
 import {DeviceDetector} from '../../esl-utils/environment/device-detector';
 import {ESLMediaQuery} from '../../esl-media-query/core';
 import {ESLFootnotes} from './esl-footnotes';
@@ -90,7 +90,7 @@ export class ESLNote extends ESLBaseElement {
   }
 
   public activate() {
-    scrollIntoViewAsync(this, {behavior: 'smooth', block: 'nearest'}).then(() => this.showTooltip());
+    scrollIntoView(this, {behavior: 'smooth', block: 'nearest'}).then(() => this.showTooltip());
   }
 
   public highlight(enable: boolean = true) {

--- a/src/modules/esl-utils/dom/scroll.ts
+++ b/src/modules/esl-utils/dom/scroll.ts
@@ -1,3 +1,4 @@
+import {tryUntil} from '../async/promise';
 import {getNodeName, getParentNode} from './api';
 
 export type ScrollStrategy = 'none' | 'native' | 'pseudo';
@@ -102,22 +103,26 @@ export function isScrollParent(element: Element): boolean {
  * This is a promise-based version of scrollIntoView().
  * Method scrolls the element's parent container such that the element on which
  * scrollIntoView() is called is visible to the user. The promise is resolved when
- * the element became visible to the user.
+ * the element became visible to the user and scrolling stops.
+ *
+ * Note: Please, use the native element.scrollIntoView() if you don't need a promise
+ * to detect the moment when the scroll is finished or you don't use smooth behavior.
  * @param element - element to be made visible to the user
  * @param options - scrollIntoView options
  */
-export function scrollIntoViewAsync(element: Element, options?: boolean | ScrollIntoViewOptions | undefined): Promise<void> {
+export function scrollIntoView(element: Element, options?: boolean | ScrollIntoViewOptions | undefined): Promise<boolean> {
+  let same = 0;
+  let lastTop: number;
+  const check = () => {
+    const newTop = element.getBoundingClientRect().top;
+
+    if (newTop !== lastTop) {
+      same = 0;
+      lastTop = newTop;
+    }
+    return same++ > 2;
+  };
+
   element.scrollIntoView(options);
-
-  return new Promise((resolve, reject) => {
-    const intersectionObserver = new IntersectionObserver((entries) => {
-      const [entry] = entries;
-
-      if (entry.isIntersecting) {
-        intersectionObserver.unobserve(element);
-        resolve();
-      }
-    });
-    intersectionObserver.observe(element);
-  });
+  return tryUntil(check, 80, 125); // will check top position every 125ms, but not more than 80 times (10s)
 }


### PR DESCRIPTION
In scope:
- renamed scrollIntoViewAsync() method with scrollIntoView()
- added to scrollIntoView() ability to detect when scrolling stops

Using this method comes in handy when you use smooth scrolling to scroll through an element in the scope and you need to know exactly when the element is visible and scrolling has finished.