### PR TITLE
feat(esl-popup): add new feature to be able to set position of arrow on popup

### DIFF
--- a/pages/views/_layouts/popup.njk
+++ b/pages/views/_layouts/popup.njk
@@ -2,27 +2,32 @@
 
 {% block body %}
 <esl-popup id="popup1" position="top">
-  Exadel Smart Library Popup content
+  <div style="height: 70px; width:250px;"></div>
   <span class="esl-popup-arrow"></span>
 </esl-popup>
 <esl-popup id="popup2" position="bottom">
-  Exadel Smart Library Popup content
+  <div style="height: 70px; width:250px;"></div>
   <span class="esl-popup-arrow"></span>
 </esl-popup>
-<esl-popup id="popup3" position="left">
-  <p>Exadel</p>
-  <p>Smart</p>
-  <p>Library</p>
-  <p>Popup</p>
-  <p>content</p>
+<esl-popup id="popup3" position="left" >
+  <div style="height: 250px; width:70px;"></div>
   <span class="esl-popup-arrow"></span>
 </esl-popup>
 <esl-popup id="popup4" position="right">
-  <p>Exadel</p>
-  <p>Smart</p>
-  <p>Library</p>
-  <p>Popup</p>
-  <p>content</p>
+  <div style="height: 250px; width:70px;"></div>
   <span class="esl-popup-arrow"></span>
+</esl-popup>
+
+<esl-popup id="popup01" position="top">
+  <div style="height: 70px; width:250px;"></div>
+</esl-popup>
+<esl-popup id="popup02" position="bottom">
+  <div style="height: 70px; width:250px;"></div>
+</esl-popup>
+<esl-popup id="popup03" position="left">
+  <div style="height: 250px; width:50px;"></div>
+</esl-popup>
+<esl-popup id="popup04" position="right">
+  <div style="height: 250px; width:50px;"></div>
 </esl-popup>
 {% endblock %}

--- a/pages/views/examples/popup.njk
+++ b/pages/views/examples/popup.njk
@@ -2,7 +2,7 @@
 layout: popup
 title: Popup
 name: Popup
-tags: [examples, draft]
+tags: [examples, beta]
 icon: examples/popup.svg
 aside:
   components:
@@ -11,7 +11,36 @@ aside:
     - esl-trigger
 ---
 
-<section class="row justify-content-between">
+<section id="popup-controls">
+  <div>
+    <label for="marginArrow">Arrow margin:</label>
+    <input type="text" id="marginArrow" name="marginArrow" min="0" max="100" value="5" size="3">
+  </div>
+  <div>
+    <label for="offsetArrow">Arrow offset:</label>
+    <input type="range" id="offsetArrow" name="offsetArrow" min="0" max="100" value="50" step="1">
+  </div>
+  <script>
+    var elMarginArrow = document.querySelector('#marginArrow');
+    var handlerMarginArrowChange = function() {
+      Array.from(document.querySelectorAll('esl-popup')).forEach(function(el) {
+        el.setAttribute('margin-arrow', elMarginArrow.value);
+      });
+    };
+    elMarginArrow.addEventListener('change', handlerMarginArrowChange);
+  </script>
+  <script>
+    var elOffsetArrow = document.querySelector('#offsetArrow');
+    var handlerOffsetArrowChange = function() {
+      Array.from(document.querySelectorAll('esl-popup')).forEach(function(el) {
+        el.setAttribute('offset-arrow', elOffsetArrow.value);
+      });
+    };
+    elOffsetArrow.addEventListener('change', handlerOffsetArrowChange);
+  </script>
+</section>
+
+<section class="row justify-content-between"">
   <esl-trigger target="#popup1" mode="toggle" class="btn btn-sec-blue">Top</esl-trigger>
   <esl-trigger target="#popup1" mode="toggle" class="btn btn-sec-blue">Top</esl-trigger>
   <esl-trigger target="#popup1" mode="toggle" class="btn btn-sec-blue">Top</esl-trigger>
@@ -26,6 +55,23 @@ aside:
   <esl-trigger target="#popup2" mode="toggle" class="btn btn-sec-blue">Bottom</esl-trigger>
   <esl-trigger target="#popup2" mode="toggle" class="btn btn-sec-blue">Bottom</esl-trigger>
   <esl-trigger target="#popup2" mode="toggle" class="btn btn-sec-blue">Bottom</esl-trigger>
+</section>
+
+<section class="row justify-content-between">
+  <esl-trigger target="#popup01" mode="toggle" class="btn btn-sec-blue">Top</esl-trigger>
+  <esl-trigger target="#popup01" mode="toggle" class="btn btn-sec-blue">Top</esl-trigger>
+  <esl-trigger target="#popup01" mode="toggle" class="btn btn-sec-blue">Top</esl-trigger>
+</section>
+
+<section class="row justify-content-between">
+  <esl-trigger target="#popup03" mode="toggle" class="btn btn-sec-blue">Left</esl-trigger>
+  <esl-trigger target="#popup04" mode="toggle" class="btn btn-sec-blue">Right</esl-trigger>
+</section>
+
+<section class="row justify-content-between">
+  <esl-trigger target="#popup02" mode="toggle" class="btn btn-sec-blue">Bottom</esl-trigger>
+  <esl-trigger target="#popup02" mode="toggle" class="btn btn-sec-blue">Bottom</esl-trigger>
+  <esl-trigger target="#popup02" mode="toggle" class="btn btn-sec-blue">Bottom</esl-trigger>
 </section>
 
 <section class="row">

--- a/src/modules/esl-popup/core/esl-popup-position.ts
+++ b/src/modules/esl-popup/core/esl-popup-position.ts
@@ -46,18 +46,18 @@ function calcBasicArrowAdjust(size: number, ratio: number): number {
    *   1 when ratio greater 0.5
    */
   const sign = Math.sign(ratio - 0.5);
-  return sign * size / 2;
+  return sign * size;
 }
 
 /**
  * Calculates the position of the popup on the minor axis
+ * @param cfg - popup position config
  * @param centerPosition - position of the center of the trigger on the minor axis
- * @param popupSize - the size of the popup by the minor axis
- * @param arrowSize - the size of the arrow by the minor axis
- * @param offsetArrowRatio - the value of the arrow offset
+ * @param dimensionName - the name of dimension (height or width)
  */
-function calcPopupPositionByMinorAxis(centerPosition: number, popupSize: number, arrowSize: number, offsetArrowRatio: number): number {
-  return centerPosition - popupSize * offsetArrowRatio + calcBasicArrowAdjust(arrowSize, offsetArrowRatio);
+function calcPopupPositionByMinorAxis(cfg: PopupPositionConfig, centerPosition: number, dimensionName: 'height' | 'width'): number {
+  return centerPosition - cfg.element[dimensionName] * cfg.offsetArrowRatio +
+    calcBasicArrowAdjust(cfg.marginArrow + cfg.arrow[dimensionName] / 2, cfg.offsetArrowRatio);
 }
 
 /**
@@ -65,21 +65,19 @@ function calcPopupPositionByMinorAxis(centerPosition: number, popupSize: number,
  * @param cfg - popup position config
  * */
 function calcPopupBasicRect(cfg: PopupPositionConfig): Rect {
-  let x = calcPopupPositionByMinorAxis(cfg.inner.cx, cfg.element.width, cfg.arrow.width, cfg.offsetArrowRatio);
+  let x = calcPopupPositionByMinorAxis(cfg, cfg.inner.cx, 'width');
   let y = cfg.inner.y - cfg.element.height;
   switch (cfg.position) {
     case 'left':
       x = cfg.inner.x - cfg.element.width;
-      // y = cfg.inner.cy - cfg.element.height * cfg.offsetArrowRatio + calcBasicArrowAdjust(cfg.arrow.height, cfg.offsetArrowRatio);
-      y = calcPopupPositionByMinorAxis(cfg.inner.cy, cfg.element.height, cfg.arrow.height, cfg.offsetArrowRatio);
+      y = calcPopupPositionByMinorAxis(cfg, cfg.inner.cy, 'height');
       break;
     case 'right':
       x = cfg.inner.right;
-      // y = cfg.inner.cy - cfg.element.height * cfg.offsetArrowRatio + calcBasicArrowAdjust(cfg.arrow.height, cfg.offsetArrowRatio);
-      y = calcPopupPositionByMinorAxis(cfg.inner.cy, cfg.element.height, cfg.arrow.height, cfg.offsetArrowRatio);
+      y = calcPopupPositionByMinorAxis(cfg, cfg.inner.cy, 'height');
       break;
     case 'bottom':
-      x = calcPopupPositionByMinorAxis(cfg.inner.cx, cfg.element.width, cfg.arrow.width, cfg.offsetArrowRatio);
+      x = calcPopupPositionByMinorAxis(cfg, cfg.inner.cx, 'width');
       y = cfg.inner.bottom;
       break;
   }

--- a/src/modules/esl-popup/core/esl-popup.less
+++ b/src/modules/esl-popup/core/esl-popup.less
@@ -1,26 +1,73 @@
 @POPUP_ARROW_SIZE: 20px;
-@POPUP_ARROW_HALF: (@POPUP_ARROW_SIZE / 2);
+@POPUP_BACKGROUND_COLOR: #FFF;
 @POPUP_BORDER_COLOR: #DBDBDB;
+@POPUP_BORDER_WIDTH: 1px;
 @POPUP_Z_INDEX: 999;
 
+.esl-popup-arrow(@popupArrowSize, @popupBackgroundColor, @popupBorderColor, @popupBorderWidth) {
+  @popupArrowHalf: (@popupArrowSize / 2);
+  @popupArrowShift: (@popupArrowSize * 0.2071 - @popupBorderWidth);  // 0.2071 = (sqrt(2) - 1) / 2  (Don't ask why, it's an axiom)
+
+  .esl-popup-arrow {
+    position: absolute;
+    top: (-@popupArrowHalf - @popupBorderWidth);
+    bottom: 100%;
+    z-index: -1;
+    transform: rotate(45deg);
+    width: @popupArrowSize;
+    height: @popupArrowSize;
+    margin-left: @popupArrowShift;
+    border-left: @popupBorderWidth solid @popupBorderColor;
+    border-top: @popupBorderWidth solid @popupBorderColor;
+    background: @popupBackgroundColor;
+  }
+
+  &[placed-at=top] {
+    .esl-popup-arrow {
+      top: auto;
+      bottom: (-@popupArrowHalf - @popupBorderWidth);
+      transform: rotate(225deg);
+    }
+  }
+
+  &[placed-at=left] {
+    .esl-popup-arrow {
+      right: (-@popupArrowHalf - @popupBorderWidth);
+      left: auto;
+      transform: rotate(135deg);
+      margin-top: @popupArrowShift;
+    }
+  }
+
+  &[placed-at=right] {
+    .esl-popup-arrow {
+      left: auto;
+      right: auto;
+      transform: rotate(315deg);
+      margin-top: @popupArrowShift;
+      margin-left: (-@popupArrowHalf - @popupBorderWidth);
+    }
+  }
+}
+
 .esl-popup {
-  display: block;
   position: absolute;
   left: 0;
   top: 0;
-  box-shadow: 1px 1px 5px rgba(0, 0, 0, 0.2);
-  border: 1px solid @POPUP_BORDER_COLOR;
-  background: #FFF;
-  cursor: default;
+  display: block;
   opacity: 0;
-  will-change: auto;
-  transition: visibility 0.5s 0.2s;
   visibility: hidden;
+  transition: visibility 0.5s 0.2s;
   box-sizing: border-box;
+  box-shadow: 1px 1px 5px rgba(0, 0, 0, 0.2);
+  border: @POPUP_BORDER_WIDTH solid @POPUP_BORDER_COLOR;
+  background: @POPUP_BACKGROUND_COLOR;
+  cursor: default;
+  will-change: auto;
 
   &[open] {
-    opacity: 1;
     z-index: @POPUP_Z_INDEX;
+    opacity: 1;
     visibility: visible;
     transition: opacity 0.15s, transform 0.2s;
   }
@@ -29,43 +76,5 @@
     display: none;
   }
 
-  .esl-popup-arrow {
-    position: absolute;
-    bottom: 100%;
-    background: #FFF;
-    width: @POPUP_ARROW_SIZE;
-    height: @POPUP_ARROW_SIZE;
-    transform: rotate(45deg);
-    margin-left: -@POPUP_ARROW_HALF;
-    top: (-@POPUP_ARROW_HALF - 1);
-    border-left: 1px solid @POPUP_BORDER_COLOR;
-    border-top: 1px solid @POPUP_BORDER_COLOR;
-    z-index: -1;
-  }
-
-  &[placed-at=top] {
-    .esl-popup-arrow {
-      bottom: (-@POPUP_ARROW_HALF - 1);
-      top: auto;
-      transform: rotate(225deg);
-    }
-  }
-
-  &[placed-at=left] {
-    .esl-popup-arrow {
-      right: (-@POPUP_ARROW_HALF - 1);
-      left: auto;
-      margin-top: -@POPUP_ARROW_HALF;
-      transform: rotate(135deg);
-    }
-  }
-
-  &[placed-at=right] {
-    .esl-popup-arrow {
-      left: auto;
-      right: auto;
-      margin-top: -@POPUP_ARROW_HALF;
-      transform: rotate(315deg);
-    }
-  }
+  .esl-popup-arrow(@POPUP_ARROW_SIZE, @POPUP_BACKGROUND_COLOR, @POPUP_BORDER_COLOR, @POPUP_BORDER_WIDTH);
 }


### PR DESCRIPTION
In the scope of this PR were made next changes:
- added new attribute offset-arrow to set up arrow position in percents of popups dimension size;
- added new attribute margin-arrow to set up the margin of the arrow in pixels to the edge of the popup;
- refactored popup styles to make it easier to position the arrow inside the popup;
- created a new mixin for popup arrow styles that takes into account the size and thickness of the arrow borders.
