### PR TITLE
feat(esl-footnotes): a few accessibility fixes

### DIFF
--- a/src/modules/esl-footnotes/core/esl-footnotes.ts
+++ b/src/modules/esl-footnotes/core/esl-footnotes.ts
@@ -4,6 +4,7 @@ import {memoize} from '../../esl-utils/decorators/memoize';
 import {ESLBaseElement, attr} from '../../esl-base-element/core';
 import {TraversingQuery} from '../../esl-traversing-query/core';
 import {EventUtils} from '../../esl-utils/dom/events';
+import {ENTER, SPACE} from '../../esl-utils/dom/keys';
 import {sequentialUID} from '../../esl-utils/misc/uid';
 import {compileFootnotesGroupedList, compileFootnotesNongroupedList, sortFootnotes} from './esl-footnotes-data';
 
@@ -63,12 +64,14 @@ export class ESLFootnotes extends ESLBaseElement {
       this.scopeEl.addEventListener(`${ESLFootnotes.eventNs}:response`, this._onNoteSubscribe);
     }
     this.addEventListener('click', this._onClick);
+    this.addEventListener('keydown', this._onKeydown);
   }
   protected unbindEvents() {
     if (this.scopeEl) {
       this.scopeEl.removeEventListener(`${ESLFootnotes.eventNs}:response`, this._onNoteSubscribe);
     }
     this.removeEventListener('click', this._onClick);
+    this.removeEventListener('keydown', this._onKeydown);
   }
 
   public linkNote(note: ESLNote) {
@@ -126,6 +129,11 @@ export class ESLFootnotes extends ESLBaseElement {
       const order = orderAttr?.split(',').map((item) => +item);
       order && this._onBackToNote(order);
     }
+  }
+
+  @bind
+  protected _onKeydown(event: KeyboardEvent) {
+    if ([ENTER, SPACE].includes(event.key)) this._onClick(event);
   }
 
   protected _onBackToNote(order: number[]) {

--- a/src/modules/esl-tooltip/core/esl-tooltip.less
+++ b/src/modules/esl-tooltip/core/esl-tooltip.less
@@ -4,4 +4,7 @@ esl-tooltip {
   width: 100%;
   max-width: @TOOLTIP_MAX_WIDTH;
   padding: 10px;
+  &:focus {
+    outline: none;
+  }
 }

--- a/src/modules/esl-tooltip/core/esl-tooltip.ts
+++ b/src/modules/esl-tooltip/core/esl-tooltip.ts
@@ -112,9 +112,9 @@ export class ESLTooltip extends ESLPopup {
   }
 
   protected _onTabKey(e: KeyboardEvent) {
-    if (this.activator &&
-        (!this.lastFocusableElement || e.target === this.lastFocusableElement) &&
-        !e.shiftKey) {
+    if (!this.activator) return;
+    const {lastFocusableElement} = this;
+    if ((!lastFocusableElement || e.target === lastFocusableElement) && !e.shiftKey) {
       this.activator.focus();
       e.stopPropagation();
       e.preventDefault();

--- a/src/modules/esl-utils/dom/focus.ts
+++ b/src/modules/esl-utils/dom/focus.ts
@@ -17,3 +17,12 @@ export const handleFocusChain = (e: KeyboardEvent, first: HTMLElement, last: HTM
     return true;
   }
 };
+
+/**
+ * Gets keyboard-focusable elements within a specified root element
+ * @param root - root element
+ */
+export const getKeyboardFocusableElements = (root: HTMLElement | Document = document): Element[] => {
+  return Array.from(root.querySelectorAll('a[href], button, input, textarea, select, details, [tabindex]:not([tabindex="-1"])'))
+    .filter(el => !el.hasAttribute('disabled') && !el.getAttribute('aria-hidden'));
+};


### PR DESCRIPTION
In scope of this PR:
- add focus out handling at esl-tooltip
- fix keydown events at esl-footnotes
