### PR TITLE
feat(esl-popup): couple new features and refactoring

### DIFF
--- a/src/modules/esl-popup/core/esl-popup-position.ts
+++ b/src/modules/esl-popup/core/esl-popup-position.ts
@@ -82,13 +82,13 @@ function getOppositePosition(position: PositionType): PositionType {
 }
 
 /**
- * Update popup and arrow positions to fit by major axis.
+ * Update popup and arrow positions to fit on major axis.
  * @param cfg - popup position config
  * @param rect - popup position rect
  * @param arrow - arrow position value
  * */
-function fitByMajorAxis(cfg: PopupPositionConfig, rect: Rect, arrow: Point): PositionType {
-  if (cfg.behavior !== 'fit') return cfg.position;
+function fitOnMajorAxis(cfg: PopupPositionConfig, rect: Rect, arrow: Point): PositionType {
+  if (cfg.behavior !== 'fit' && cfg.behavior !== 'fit-on-major') return cfg.position;
 
   let isMirrored = false;
   switch (cfg.position) {
@@ -122,12 +122,12 @@ function fitByMajorAxis(cfg: PopupPositionConfig, rect: Rect, arrow: Point): Pos
 }
 
 /**
- * Update popup and arrow positions to fit by minor horizontal axis.
+ * Update popup and arrow positions to fit on minor horizontal axis.
  * @param cfg - popup position config
  * @param rect - popup position rect
  * @param arrow - arrow position value
  * */
-function fitByMinorAxisHorizontal(cfg: PopupPositionConfig, rect: Rect, arrow: Point): void {
+function fitOnMinorAxisHorizontal(cfg: PopupPositionConfig, rect: Rect, arrow: Point): void {
   if (cfg.trigger.x < cfg.outer.x || cfg.trigger.right > cfg.outer.right) return; // cancel fit mode if the element is out of window offset bounds
 
   let arrowAdjust = 0;
@@ -149,7 +149,7 @@ function fitByMinorAxisHorizontal(cfg: PopupPositionConfig, rect: Rect, arrow: P
  * @param rect - popup position rect
  * @param arrow - arrow position value
  * */
-function fitByMinorAxisVertical(cfg: PopupPositionConfig, rect: Rect, arrow: Point): void {
+function fitOnMinorAxisVertical(cfg: PopupPositionConfig, rect: Rect, arrow: Point): void {
   if (cfg.trigger.y < cfg.outer.y || cfg.trigger.bottom > cfg.outer.bottom) return; // cancel fit mode if the element is out of window offset bounds
 
   let arrowAdjust = 0;
@@ -165,18 +165,18 @@ function fitByMinorAxisVertical(cfg: PopupPositionConfig, rect: Rect, arrow: Poi
 }
 
 /**
- * Update popup and arrow positions to fit by minor axis.
+ * Update popup and arrow positions to fit on minor axis.
  * @param cfg - popup position config
  * @param rect - popup position rect
  * @param arrow - arrow position value
  * */
-function fitByMinorAxis(cfg: PopupPositionConfig, rect: Rect, arrow: Point): void {
-  if (cfg.behavior !== 'fit') return;
+function fitOnMinorAxis(cfg: PopupPositionConfig, rect: Rect, arrow: Point): void {
+  if (cfg.behavior !== 'fit' && cfg.behavior !== 'fit-on-minor') return;
 
   if (['left', 'right'].includes(cfg.position)) {
-    fitByMinorAxisVertical(cfg, rect, arrow);
+    fitOnMinorAxisVertical(cfg, rect, arrow);
   } else {
-    fitByMinorAxisHorizontal(cfg, rect, arrow);
+    fitOnMinorAxisHorizontal(cfg, rect, arrow);
   }
 }
 
@@ -201,8 +201,8 @@ export function calcPopupPosition(cfg: PopupPositionConfig): PopupPositionValue 
     position: cfg.position
   };
 
-  const placedAt = fitByMajorAxis(cfg, popup, arrow);
-  fitByMinorAxis(cfg, popup, arrow);
+  const placedAt = fitOnMajorAxis(cfg, popup, arrow);
+  fitOnMinorAxis(cfg, popup, arrow);
 
   return {
     popup,

--- a/src/modules/esl-popup/core/esl-popup.shape.ts
+++ b/src/modules/esl-popup/core/esl-popup.shape.ts
@@ -9,6 +9,12 @@ import type {PositionType} from './esl-popup-position';
 export interface ESLPopupShape extends ESLToggleableTagShape<ESLPopup> {
   /** Popup behavior if it does not fit in the window ('fit' by default) */
   behavior?: string;
+  /** Disable hiding the popup depending on the visibility of the activator */
+  disableActivatorObservation?: boolean;
+  /** Margins on the edges of the arrow. */
+  marginArrow?: string;
+  /** Offset of the arrow as a percentage of the popup edge (0% - at the left edge, 100% - at the right edge, for RTL it is vice versa) */
+  offsetArrow?: string;
   /**
    * Popup position relative to the trigger.
    * Currently supported: 'top', 'bottom', 'left', 'right' position types ('top' by default)

--- a/src/modules/esl-popup/core/esl-popup.ts
+++ b/src/modules/esl-popup/core/esl-popup.ts
@@ -2,6 +2,7 @@ import {range} from '../../esl-utils/misc/array';
 import {ExportNs} from '../../esl-utils/environment/export-ns';
 import {attr, boolAttr, jsonAttr} from '../../esl-base-element/core';
 import {bind} from '../../esl-utils/decorators/bind';
+import {memoize} from '../../esl-utils/decorators/memoize';
 import {ready} from '../../esl-utils/decorators/ready';
 import {prop} from '../../esl-utils/decorators/prop';
 import {rafDecorator} from '../../esl-utils/async/raf';
@@ -11,7 +12,7 @@ import {RTLUtils} from '../../esl-utils/dom/rtl';
 import {getListScrollParents} from '../../esl-utils/dom/scroll';
 import {getWindowRect} from '../../esl-utils/dom/window';
 import {parseNumber} from '../../esl-utils/misc/format';
-import {calcPopupPosition} from './esl-popup-position';
+import {calcPopupPosition, isMajorAxisHorizontal} from './esl-popup-position';
 
 import type {ToggleableActionParams} from '../../esl-toggleable/core';
 import type {PositionType, IntersectionRatioRect} from './esl-popup-position';
@@ -96,22 +97,25 @@ export class ESLPopup extends ESLToggleable {
   @prop() public closeOnOutsideAction = true;
 
   @ready
-  public connectedCallback() {
+  public connectedCallback(): void {
     super.connectedCallback();
     this.$arrow = this.querySelector('span.esl-popup-arrow');
   }
 
-  /** Is position along horizontal axis? */
-  protected get _isPositioningAlongHorizontal() {
-    return ['left', 'right'].includes(this.position);
+  /** Checks that the position along the horizontal axis */
+  @memoize()
+  protected get _isMajorAxisHorizontal(): boolean {
+    return isMajorAxisHorizontal(this.position);
   }
 
-  /** Is position along vertical axis? */
-  protected get _isPositioningAlongVertical() {
-    return ['top', 'bottom'].includes(this.position);
+  /** Checks that the position along the vertical axis */
+  @memoize()
+  protected get _isMajorAxisVertical(): boolean {
+    return !isMajorAxisHorizontal(this.position);
   }
 
   /** Get offsets arrow ratio */
+  @memoize()
   protected get _offsetArrowRatio(): number {
     const ratio = parsePercent(this.offsetArrow, DEFAULT_OFFSET_ARROW) / 100;
     return RTLUtils.isRtl(this) ? 1 - ratio : ratio;
@@ -122,7 +126,7 @@ export class ESLPopup extends ESLToggleable {
    * Inner state and 'open' attribute are not affected and updated before `onShow` execution.
    * Adds CSS classes, update a11y and fire esl:refresh event by default.
    */
-  public onShow(params: PopupActionParams) {
+  public onShow(params: PopupActionParams): void {
     super.onShow(params);
 
     if (params.position) {
@@ -158,18 +162,23 @@ export class ESLPopup extends ESLToggleable {
    * Inner state and 'open' attribute are not affected and updated before `onShow` execution.
    * Removes CSS classes and update a11y by default.
    */
-  public onHide(params: PopupActionParams) {
+  public onHide(params: PopupActionParams): void {
     super.onHide(params);
 
     this._stopUpdateLoop();
     this.activator && this._removeActivatorObserver(this.activator);
+
+    // clear all memoize data
+    memoize.clear(this, '_isMajorAxisHorizontal');
+    memoize.clear(this, '_isMajorAxisVertical');
+    memoize.clear(this, '_offsetArrowRatio');
   }
 
   /**
    * Checks activator intersection for adjacent axis.
    * Hides the popup if the intersection ratio exceeds the limit.
    */
-  protected _checkIntersectionForAdjacentAxis(isAdjacentAxis: boolean, intersectionRatio: number) {
+  protected _checkIntersectionForAdjacentAxis(isAdjacentAxis: boolean, intersectionRatio: number): void {
     if (isAdjacentAxis && intersectionRatio < INTERSECTION_LIMIT_FOR_ADJACENT_AXIS) {
       this.hide();
     }
@@ -177,7 +186,7 @@ export class ESLPopup extends ESLToggleable {
 
   /** Actions to execute on activator intersection event. */
   @bind
-  protected onActivatorIntersection(entries: IntersectionObserverEntry[], observer: IntersectionObserver) {
+  protected onActivatorIntersection(entries: IntersectionObserverEntry[], observer: IntersectionObserver): void {
     const entry = entries[0];
     this._intersectionRatio = {};
     if (!entry.isIntersecting) {
@@ -187,25 +196,25 @@ export class ESLPopup extends ESLToggleable {
 
     if (entry.intersectionRect.y !== entry.boundingClientRect.y) {
       this._intersectionRatio.top = entry.intersectionRect.height / entry.boundingClientRect.height;
-      this._checkIntersectionForAdjacentAxis(this._isPositioningAlongHorizontal, this._intersectionRatio.top);
+      this._checkIntersectionForAdjacentAxis(this._isMajorAxisHorizontal, this._intersectionRatio.top);
     }
     if (entry.intersectionRect.bottom !== entry.boundingClientRect.bottom) {
       this._intersectionRatio.bottom = entry.intersectionRect.height / entry.boundingClientRect.height;
-      this._checkIntersectionForAdjacentAxis(this._isPositioningAlongHorizontal, this._intersectionRatio.bottom);
+      this._checkIntersectionForAdjacentAxis(this._isMajorAxisHorizontal, this._intersectionRatio.bottom);
     }
     if (entry.intersectionRect.x !== entry.boundingClientRect.x) {
       this._intersectionRatio.left = entry.intersectionRect.width / entry.boundingClientRect.width;
-      this._checkIntersectionForAdjacentAxis(this._isPositioningAlongVertical, this._intersectionRatio.left);
+      this._checkIntersectionForAdjacentAxis(this._isMajorAxisVertical, this._intersectionRatio.left);
     }
     if (entry.intersectionRect.right !== entry.boundingClientRect.right) {
       this._intersectionRatio.right = entry.intersectionRect.width / entry.boundingClientRect.width;
-      this._checkIntersectionForAdjacentAxis(this._isPositioningAlongVertical, this._intersectionRatio.right);
+      this._checkIntersectionForAdjacentAxis(this._isMajorAxisVertical, this._intersectionRatio.right);
     }
   }
 
   /** Actions to execute on activator scroll event. */
   @bind
-  protected onActivatorScroll(e: Event) {
+  protected onActivatorScroll(e: Event): void {
     if (this._updateLoopID) return;
     this._updatePosition();
   }
@@ -241,7 +250,7 @@ export class ESLPopup extends ESLToggleable {
   }
 
   /** Removes activator listeners and observers after hiding popup */
-  protected _removeActivatorObserver(target: HTMLElement) {
+  protected _removeActivatorObserver(target: HTMLElement): void {
     window.removeEventListener('resize', this._deferredUpdatePosition);
     window.removeEventListener('scroll', this.onActivatorScroll, scrollOptions);
     this._activatorObserver.observer?.disconnect();
@@ -258,7 +267,7 @@ export class ESLPopup extends ESLToggleable {
    * for the last 2 frames of the animation.
    */
   @bind
-  protected _startUpdateLoop() {
+  protected _startUpdateLoop(): void {
     if (this._updateLoopID) return;
 
     let same = 0;
@@ -291,14 +300,14 @@ export class ESLPopup extends ESLToggleable {
    * Also cancels the animation frame request.
    */
   @bind
-  protected _stopUpdateLoop() {
+  protected _stopUpdateLoop(): void {
     if (!this._updateLoopID) return;
     cancelAnimationFrame(this._updateLoopID);
     this._updateLoopID = 0;
   }
 
   /** Updates position of popup and its arrow */
-  protected _updatePosition() {
+  protected _updatePosition(): void {
     if (!this.activator) return;
 
     const triggerRect = this.activator.getBoundingClientRect();
@@ -328,8 +337,8 @@ export class ESLPopup extends ESLToggleable {
     this.style.top = `${popup.y}px`;
     // set arrow position
     if (this.$arrow) {
-      this.$arrow.style.left = ['top', 'bottom'].includes(placedAt) ? `${arrow.x}px` : '';
-      this.$arrow.style.top = ['left', 'right'].includes(placedAt) ? `${arrow.y}px` : '';
+      this.$arrow.style.left = this._isMajorAxisVertical ? `${arrow.x}px` : '';
+      this.$arrow.style.top = this._isMajorAxisHorizontal ? `${arrow.y}px` : '';
     }
   }
 }

--- a/src/modules/esl-popup/core/esl-popup.ts
+++ b/src/modules/esl-popup/core/esl-popup.ts
@@ -7,6 +7,7 @@ import {prop} from '../../esl-utils/decorators/prop';
 import {rafDecorator} from '../../esl-utils/async/raf';
 import {ESLToggleable} from '../../esl-toggleable/core';
 import {Rect} from '../../esl-utils/dom/rect';
+import {RTLUtils} from '../../esl-utils/dom/rtl';
 import {getListScrollParents} from '../../esl-utils/dom/scroll';
 import {getWindowRect} from '../../esl-utils/dom/window';
 import {parseNumber} from '../../esl-utils/misc/format';
@@ -68,7 +69,7 @@ export class ESLPopup extends ESLToggleable {
   /** Disable hiding the popup depending on the visibility of the activator */
   @attr({defaultValue: 'fit'}) public behavior: string;
 
-  /** */
+  /** Disable hiding the popup depending on the visibility of the activator */
   @boolAttr() public disableActivatorObservation: boolean;
   /**
    * Margins on the edges of the arrow.
@@ -111,8 +112,9 @@ export class ESLPopup extends ESLToggleable {
   }
 
   /** Get offsets arrow ratio */
-  protected get _offsetArrowRatio() {
-    return parsePercent(this.offsetArrow, DEFAULT_OFFSET_ARROW) / 100;
+  protected get _offsetArrowRatio(): number {
+    const ratio = parsePercent(this.offsetArrow, DEFAULT_OFFSET_ARROW) / 100;
+    return RTLUtils.isRtl(this) ? 1 - ratio : ratio;
   }
 
   /**


### PR DESCRIPTION
In scope of this PR:
 - added `disable-activator-observation` attribute to let popup leaves viewport without hiding
 - added new `fit-on-major` value for the behavior attribute so that the popup update its position in order to fit on the major axis only
 - added new `fit-on-minor` value for the behavior attribute so that the popup update its position in order to fit on the minor axis only
 - added RTL support, resulting in a popup mirrored relative to the major axis
 - updated TSX shapes
 - refactor code to achieve the best performance during popup position updating