### PR TITLE
fix(esl-panel): Animation end handling

### DIFF
--- a/src/modules/esl-panel-group/README.md
+++ b/src/modules/esl-panel-group/README.md
@@ -21,7 +21,7 @@ ESLPanelGroup.register();
 - `mode-cls` - rendering mode class pattern (default: `esl-{mode}-view`). Uses ESLUtils `format` syntax for `mode` placeholder
 - `mode-cls-target` - Element [ESLTraversingQuery](../esl-traversing-query/README.md)  selector to add class that identifies mode (ESLPanelGroup itself by default)
 - `animation-class` - class(es) to be added during animation ('animate' by default)
-- `fallback-duration` - time to clear animation common params (max-height style + classes) (2s by default)
+- `fallback-duration` - time to clear animation common params (max-height style + classes)
 - `no-collapse` - list of comma-separated "modes" to disable collapse/expand animation (for both Group and Panel animations)
 - `accordion-group` - defines accordion behavior: 
   * `single` (default) allows only one Panel to be open

--- a/src/modules/esl-panel-group/core/esl-panel-group.ts
+++ b/src/modules/esl-panel-group/core/esl-panel-group.ts
@@ -31,8 +31,8 @@ export class ESLPanelGroup extends ESLBaseElement {
   @attr({defaultValue: ''}) public modeClsTarget: string;
   /** Class(es) to be added during animation ('animate' by default) */
   @attr({defaultValue: 'animate'}) public animationClass: string;
-  /** Time to clear animation common params (max-height style + classes) ('auto' by default) */
-  @attr({defaultValue: 'auto'}) public fallbackDuration: number | 'auto';
+  /** Time to clear animation common params (max-height style + classes) */
+  @attr() public fallbackDuration: number | 'auto' | '';
   /** List of comma-separated "modes" to disable collapse/expand animation (for both Group and Panel animations) */
   @attr() public noCollapse: string;
   /**
@@ -206,6 +206,7 @@ export class ESLPanelGroup extends ESLBaseElement {
   /** Animates the height of the component */
   protected onAnimate(from: number, to: number): void {
     const hasCurrent = this.style.height && this.style.height !== 'auto';
+    if (from === to) this.afterAnimate();
     if (hasCurrent) {
       this.style.height = `${to}px`;
       this.fallbackAnimate();
@@ -233,6 +234,7 @@ export class ESLPanelGroup extends ESLBaseElement {
 
   /** Inits a fallback timer to call post-animate action */
   protected fallbackAnimate(): void {
+    if (!this.fallbackDuration) return;
     const time = +this.fallbackDuration;
     if (isNaN(time) || time < 0) return;
     if (this._fallbackTimer) clearTimeout(this._fallbackTimer);

--- a/src/modules/esl-panel/README.md
+++ b/src/modules/esl-panel/README.md
@@ -19,7 +19,7 @@ ESLPanel.register();
  - `active-class` - class(es) to be added for active state ('open' by default)
  - `animate-class` - class(es) to be added during animation ('animate' by default)
  - `post-animate-class` - class(es) to be added during animation after next render ('post-animate' by default)
- - `fallback-duration` - time to clear animation common params (max-height style + classes) (1s by default)
+ - `fallback-duration` - time to clear animation common params (max-height style + classes)
  - `initial-params` - initial params for current ESLPanel instance
  - `animating` - marker of animation process running
 

--- a/src/modules/esl-panel/core/esl-panel.ts
+++ b/src/modules/esl-panel/core/esl-panel.ts
@@ -32,8 +32,8 @@ export class ESLPanel extends ESLToggleable {
   @attr({defaultValue: 'animate'}) public animateClass: string;
   /** Class(es) to be added during animation after next render ('post-animate' by default) */
   @attr({defaultValue: 'post-animate'}) public postAnimateClass: string;
-  /** Time to clear animation common params (max-height style + classes) (1s by default) */
-  @attr({defaultValue: '1000'}) public fallbackDuration: number | 'auto';
+  /** Time to clear animation common params (max-height style + classes) */
+  @attr() public fallbackDuration: number | 'auto' | '';
 
   /** Initial params for current ESLPanel instance */
   @jsonAttr<PanelActionParams>({defaultValue: {force: true, initiator: 'init'}})
@@ -104,6 +104,7 @@ export class ESLPanel extends ESLToggleable {
   /** Process animation */
   protected onAnimate(action: string): void {
     // set initial height
+    if (this.initialHeight === 0) this.afterAnimate();
     this.style.setProperty('max-height', `${action === 'hide' ? this._initialHeight : 0}px`);
     // make sure that browser apply initial height for animation
     afterNextRender(() => {
@@ -128,6 +129,7 @@ export class ESLPanel extends ESLToggleable {
 
   /** Init a fallback timer to call post-animate action */
   protected fallbackAnimate(): void {
+    if (!this.fallbackDuration) return;
     const time = +this.fallbackDuration;
     if (isNaN(time) || time < 0) return;
     if (this._fallbackTimer) clearTimeout(this._fallbackTimer);


### PR DESCRIPTION
In the scope of this PR I fixed issue where function that executes after animation end wasn't firing. The problem was that transition didn't execute when transition property value didn't change. As a result fallback-duration attribute which handled the issue before is now optional and doesn't have default value