### PR TITLE
feat(esl-utils): update promisifyTimeout with extended syntax support

### DIFF
--- a/src/modules/esl-utils/async/promise.ts
+++ b/src/modules/esl-utils/async/promise.ts
@@ -1,7 +1,8 @@
 import type {AnyToAnyFnSignature} from '../misc/functions';
 
 /**
- * @returns Promise that will be resolved in `timeout` with optional `payload` if `isReject` is true, and will be rejected if `isReject` is false
+ * @returns Promise that will be resolved or rejected in `timeout` with an optional `payload`
+ * If `isReject` is `true` the result promise will be rejected, otherwise (by default) the result promise will be resolved
  */
 export function promisifyTimeout<T>(timeout: number, payload?: T, isReject?: boolean): Promise<T> {
   return new Promise<T>((resolve, reject) =>

--- a/src/modules/esl-utils/async/promise.ts
+++ b/src/modules/esl-utils/async/promise.ts
@@ -3,9 +3,9 @@ import type {AnyToAnyFnSignature} from '../misc/functions';
 /**
  * @returns Promise that will be resolved in `timeout` with optional `payload`
  */
-export function promisifyTimeout<T>(timeout: number, payload?: T): Promise<T> {
-  return new Promise<T>((resolve) =>
-    setTimeout(resolve.bind(null, payload), timeout)
+export function promisifyTimeout<T>(timeout: number, payload?: T, isReject?: boolean): Promise<T> {
+  return new Promise<T>((resolve, reject) =>
+    setTimeout((isReject ? reject : resolve).bind(null, payload), timeout)
   );
 }
 

--- a/src/modules/esl-utils/async/promise.ts
+++ b/src/modules/esl-utils/async/promise.ts
@@ -1,7 +1,7 @@
 import type {AnyToAnyFnSignature} from '../misc/functions';
 
 /**
- * @returns Promise that will be resolved in `timeout` with optional `payload`
+ * @returns Promise that will be resolved in `timeout` with optional `payload` if `isReject` is true, and will be rejected if `isReject` is false
  */
 export function promisifyTimeout<T>(timeout: number, payload?: T, isReject?: boolean): Promise<T> {
   return new Promise<T>((resolve, reject) =>

--- a/src/modules/esl-utils/async/test/promise.test.ts
+++ b/src/modules/esl-utils/async/test/promise.test.ts
@@ -39,7 +39,22 @@ describe('promise utils', () => {
   });
 
   describe('promisifyTimeout', () => {
-    test('promisifyTimeout', () => {
+    test('resolve without payload', () => {
+      const promise$ = promisifyTimeout(100);
+      jest.advanceTimersByTime(100);
+      return expect(promise$).resolves.toBeUndefined();
+    });
+    test('resolve', () => {
+      const promise$ = promisifyTimeout(100, true);
+      jest.advanceTimersByTime(100);
+      return expect(promise$).resolves.toBe(true);
+    });
+    test('reject', () => {
+      const promise$ = promisifyTimeout(100, false, true);
+      jest.advanceTimersByTime(100);
+      return expect(promise$).rejects.toBe(false);
+    });
+    test('timeout', () => {
       const resCb = jest.fn();
       const rejCb = jest.fn();
 
@@ -50,8 +65,6 @@ describe('promise utils', () => {
       expect(resCb).not.toBeCalled();
       expect(rejCb).not.toBeCalled();
       jest.advanceTimersByTime(100);
-
-      return expect(promise$).resolves.toBe(true);
     });
   });
 


### PR DESCRIPTION
Created extended version of `promisifyTimeout` method #858

Closes: #858