### PR TITLE
fix(esl-utils): move attribute decorators to the `esl-utils`

### DIFF
--- a/pages/src/navigation/sidebar/sidebar.ts
+++ b/pages/src/navigation/sidebar/sidebar.ts
@@ -1,7 +1,7 @@
+import {attr} from '../../../../src/modules/esl-utils/decorators/attr';
 import {prop} from '../../../../src/modules/esl-utils/decorators/prop';
 import {bind} from '../../../../src/modules/esl-utils/decorators/bind';
 import {ready} from '../../../../src/modules/esl-utils/decorators/ready';
-import {attr} from '../../../../src/modules/esl-base-element/decorators/attr';
 import {ESLToggleable} from '../../../../src/modules/esl-toggleable/core/esl-toggleable';
 import {ESLMediaQuery} from '../../../../src/modules/esl-media-query/core/esl-media-query';
 

--- a/src/modules/esl-base-element/core.ts
+++ b/src/modules/esl-base-element/core.ts
@@ -2,6 +2,6 @@ export type {ESLBaseElementShape} from './core/esl-base-element.shape';
 
 export * from './core/esl-base-element';
 
-export * from './decorators/attr';
-export * from './decorators/bool-attr';
-export * from './decorators/json-attr';
+export * from '../esl-utils/decorators/attr';
+export * from '../esl-utils/decorators/bool-attr';
+export * from '../esl-utils/decorators/json-attr';

--- a/src/modules/esl-tab/core/esl-tab.ts
+++ b/src/modules/esl-tab/core/esl-tab.ts
@@ -1,6 +1,6 @@
+import {attr} from '../../esl-utils/decorators/attr';
 import {ExportNs} from '../../esl-utils/environment/export-ns';
 import {ESLTrigger} from '../../esl-trigger/core';
-import {attr} from '../../esl-base-element/decorators/attr';
 
 /**
  * ESlTab component

--- a/src/modules/esl-utils/decorators/attr.ts
+++ b/src/modules/esl-utils/decorators/attr.ts
@@ -1,6 +1,6 @@
-import {toKebabCase} from '../../esl-utils/misc/format';
-import {getAttr, setAttr} from '../../esl-utils/dom/attr';
-import type {AttributeDecorator, AttributeTarget} from '../../esl-utils/dom/attr';
+import {toKebabCase} from '../misc/format';
+import {getAttr, setAttr} from '../dom/attr';
+import type {AttributeDecorator, AttributeTarget} from '../dom/attr';
 
 /** HTML attribute mapping configuration */
 type AttrDescriptor = {

--- a/src/modules/esl-utils/decorators/bool-attr.ts
+++ b/src/modules/esl-utils/decorators/bool-attr.ts
@@ -1,6 +1,6 @@
-import {setAttr} from '../../esl-utils/dom/attr';
-import {toKebabCase} from '../../esl-utils/misc/format';
-import type {AttributeDecorator, AttributeTarget} from '../../esl-utils/dom/attr';
+import {setAttr} from '../dom/attr';
+import {toKebabCase} from '../misc/format';
+import type {AttributeDecorator, AttributeTarget} from '../dom/attr';
 
 /** HTML boolean (marker) attribute mapping configuration */
 type BoolAttrDescriptor = {

--- a/src/modules/esl-utils/decorators/json-attr.ts
+++ b/src/modules/esl-utils/decorators/json-attr.ts
@@ -1,6 +1,6 @@
-import {getAttr, setAttr} from '../../esl-utils/dom/attr';
-import {toKebabCase, evaluate} from '../../esl-utils/misc/format';
-import type {AttributeDecorator, AttributeTarget} from '../../esl-utils/dom/attr';
+import {getAttr, setAttr} from '../dom/attr';
+import {toKebabCase, evaluate} from '../misc/format';
+import type {AttributeDecorator, AttributeTarget} from '../dom/attr';
 
 /** HTML attribute to object property mapping configuration */
 interface JsonAttrDescriptor<T> {

--- a/src/modules/esl-utils/decorators/test/attr.test.ts
+++ b/src/modules/esl-utils/decorators/test/attr.test.ts
@@ -1,9 +1,9 @@
-import '../../../polyfills/es5-target-shim';
-import {ESLBaseElement, attr} from '../core';
+import '../../../../polyfills/es5-target-shim';
+import {attr} from '../attr';
 
 describe('Decorator: attr', () => {
 
-  class TestElement extends ESLBaseElement {
+  class TestElement extends HTMLElement {
     @attr()
     public fieldDefault: string | boolean;
     @attr({defaultValue: null})
@@ -19,8 +19,7 @@ describe('Decorator: attr', () => {
     @attr({defaultValue: 'def'})
     public defField: string | boolean;
   }
-
-  TestElement.register('test-el-attr');
+  customElements.define('test-el-attr', TestElement);
   const el = new TestElement();
 
   beforeAll(() => {

--- a/src/modules/esl-utils/decorators/test/bool-attr.test.ts
+++ b/src/modules/esl-utils/decorators/test/bool-attr.test.ts
@@ -1,9 +1,9 @@
-import '../../../polyfills/es5-target-shim';
-import {ESLBaseElement, boolAttr} from '../core';
+import '../../../../polyfills/es5-target-shim';
+import {boolAttr} from '../bool-attr';
 
 describe('Decorator: boolAttr', () => {
 
-  class TestElement extends ESLBaseElement {
+  class TestElement extends HTMLElement {
     @boolAttr()
     public fieldDefault: boolean;
     @boolAttr({dataAttr: true})
@@ -16,8 +16,7 @@ describe('Decorator: boolAttr', () => {
     public readonlyField: boolean;
   }
 
-  TestElement.register('test-el-bool');
-
+  customElements.define('test-el-bool', TestElement);
   const el = new TestElement();
 
   beforeAll(() => {

--- a/src/modules/esl-utils/decorators/test/json-attr.test.ts
+++ b/src/modules/esl-utils/decorators/test/json-attr.test.ts
@@ -1,9 +1,9 @@
-import '../../../polyfills/es5-target-shim';
-import {ESLBaseElement, jsonAttr} from '../core';
+import '../../../../polyfills/es5-target-shim';
+import {jsonAttr} from '../json-attr';
 
 describe('Decorator: jsonAttr', () => {
 
-  class TestElement extends ESLBaseElement {
+  class TestElement extends HTMLElement {
     @jsonAttr()
     public simple: any;
     @jsonAttr({dataAttr: true})
@@ -18,10 +18,12 @@ describe('Decorator: jsonAttr', () => {
     public defSimple: any;
   }
 
-  TestElement.register('test-el-bool');
-
+  customElements.define('test-el-bool', TestElement);
   const el = new TestElement();
-  document.body.append(el);
+
+  beforeAll(() => {
+    document.body.append(el);
+  });
 
   test('Decorator: jsonAttr - simple', () => {
     expect(el.simple).toEqual({});


### PR DESCRIPTION
Relates to: #878