### PR TITLE
fix(esl-utils): add IE compatibility for window rect obtaining

### DIFF
--- a/src/modules/esl-utils/dom/window.ts
+++ b/src/modules/esl-utils/dom/window.ts
@@ -17,8 +17,8 @@ export function getWindow(node: Node | Window): Window {
  */
 export function getWindowRect(wnd: Window = window): Rect {
   return Rect.from({
-    x: wnd.scrollX,
-    y: wnd.scrollY,
+    x: wnd.scrollX || wnd.pageXOffset,
+    y: wnd.scrollY || wnd.pageYOffset,
     width: wnd.innerWidth || wnd.document.documentElement.clientWidth,
     height: wnd.innerHeight || wnd.document.documentElement.clientHeight
   });


### PR DESCRIPTION
In bounds of this PR:
- added Internet Explorer compatibility for window rect obtaining