### PR TITLE
fix(esl-panel-group): fix esl:before:hide bubbling from uncontrolled toggleables

### DIFF
--- a/src/modules/esl-panel-group/core/esl-panel-group.ts
+++ b/src/modules/esl-panel-group/core/esl-panel-group.ts
@@ -262,13 +262,13 @@ export class ESLPanelGroup extends ESLBaseElement {
   /** Process {@link ESLPanel} pre-hide event */
   @bind
   protected _onBeforeHide(e: CustomEvent): void {
-    // TODO: refactor
+    const panel = e.target;
+    if (!this.includesPanel(panel)) return;
     if (this.currentMode === 'open') {
+      // TODO: refactor
       e.preventDefault();
       return;
     }
-    const panel = e.target;
-    if (!this.includesPanel(panel)) return;
     this._previousHeight = this.clientHeight;
   }
 


### PR DESCRIPTION
Fix `esl:before:hide` bubbling from uncontrolled toggleables