### PR TITLE
feat(esl-utils): rework subscription API

### DIFF
--- a/src/modules/esl-base-element/core/esl-base-element.ts
+++ b/src/modules/esl-base-element/core/esl-base-element.ts
@@ -24,7 +24,8 @@ export abstract class ESLBaseElement extends HTMLElement {
     this._connected = true;
     this.classList.add((this.constructor as typeof ESLBaseElement).is);
 
-    EventUtils.subscribe(this);
+    EventUtils.descriptors(this)
+      .forEach((desc) => EventUtils.subscribe(this, desc));
   }
   protected disconnectedCallback(): void {
     this._connected = false;

--- a/src/modules/esl-utils/decorators/test/listen.test.ts
+++ b/src/modules/esl-utils/decorators/test/listen.test.ts
@@ -1,7 +1,7 @@
 import '../../../../polyfills/es5-target-shim';
 
 import {listen} from '../listen';
-import {ESLEventListener} from '../../dom/events';
+import {EventUtils} from '../../dom/events';
 
 describe('Decorator: listen', () => {
   test('short', () => {
@@ -12,8 +12,8 @@ describe('Decorator: listen', () => {
     customElements.define('test-listen-1', Test);
 
     const test = new Test();
-    expect(ESLEventListener.descriptors(test).length).toBe(1);
-    expect(ESLEventListener.descriptors(test)[0].event).toBe('click');
+    expect(EventUtils.descriptors(test).length).toBe(1);
+    expect(EventUtils.descriptors(test)[0].event).toBe('click');
   });
 
   test('full', () => {
@@ -26,7 +26,7 @@ describe('Decorator: listen', () => {
     customElements.define('test-listen-2', Test);
 
     const test = new Test();
-    expect(ESLEventListener.descriptors(test).length).toBe(2);
+    expect(EventUtils.descriptors(test).length).toBe(2);
   });
 
   test('inheritance', () => {
@@ -41,7 +41,7 @@ describe('Decorator: listen', () => {
     customElements.define('test-listen-3', TestInh);
 
     const test = new TestInh();
-    expect(ESLEventListener.descriptors(test).length).toBe(2);
+    expect(EventUtils.descriptors(test).length).toBe(2);
   });
 
   test('multiple decoration', () => {

--- a/src/modules/esl-utils/dom/events/listener.ts
+++ b/src/modules/esl-utils/dom/events/listener.ts
@@ -35,12 +35,6 @@ export type ESLListenerDescriptor<EType extends keyof ESLListenerEventMap = stri
 /** Condition (criteria) to find {@link ESLListenerDescriptor} */
 export type ESLListenerCriteria = undefined | keyof ESLListenerEventMap | ESLListenerHandler | Partial<ESLEventListener>;
 
-/** Function decorated as {@link ESLListenerDescriptor} */
-export type ESLListenerDescriptorFn = ESLListenerHandler & ESLListenerDescriptor;
-
-/** Type guard to check if the passed function is typeof {@link ESLListenerDescriptorFn} */
-export const isDescriptorFn = (obj: any): obj is ESLListenerDescriptorFn => typeof obj === 'function' && typeof obj.event === 'string';
-
 const STORE = '__listeners';
 
 /** Event Listener instance, used as an 'inner' record to process subscriptions made by `EventUtils` */
@@ -126,16 +120,6 @@ export class ESLEventListener implements ESLListenerDescriptor {
     if (!host) return [];
     if (!Object.hasOwnProperty.call(host, STORE)) host[STORE] = [];
     return host[STORE];
-  }
-
-  /** Gets descriptors from the passed object */
-  public static descriptors(target?: any): ESLListenerDescriptorFn[] {
-    if (!target) return [];
-    const desc: ESLListenerDescriptorFn[] = [];
-    for (const key in target) {
-      if (isDescriptorFn(target[key])) desc.push(target[key]);
-    }
-    return desc;
   }
 
   /** Creates event listeners by handler and descriptors */

--- a/src/modules/esl-utils/dom/events/listener.ts
+++ b/src/modules/esl-utils/dom/events/listener.ts
@@ -79,7 +79,7 @@ export class ESLEventListener implements ESLListenerDescriptor {
   public matches(desc?: ESLListenerCriteria): boolean {
     if (typeof desc === 'string') return this.event === desc;
     if (typeof desc === 'function') return this.handler === desc;
-    if (typeof desc === 'object') return isSimilar(this, desc);
+    if (typeof desc === 'object') return isSimilar(this, desc, false);
     return false;
   }
 

--- a/src/modules/esl-utils/dom/events/test/listener.test.ts
+++ b/src/modules/esl-utils/dom/events/test/listener.test.ts
@@ -13,33 +13,6 @@ describe('dom/events: ESLEventListener', () => {
     });
   });
 
-  describe('descriptors', () => {
-    test('basic test 1', () => {
-      const fn1 = () => undefined;
-      const fn2 = () => undefined;
-      fn1.event = fn2.event = 'test';
-
-      const obj = {onClick: fn1};
-      const proto = {onEvent: fn2};
-      Object.setPrototypeOf(obj, proto);
-
-      const desc = ESLEventListener.descriptors(obj);
-      expect(Array.isArray(desc)).toBe(true);
-      expect(desc.includes(fn1));
-      expect(desc.includes(fn2));
-    });
-    test('basic test 2', () => {
-      const obj: any = document.createElement('div');
-
-      expect(ESLEventListener.descriptors(obj)).toEqual([]);
-
-      obj.onEvent = Object.assign(() => undefined, {event: 'event'});
-
-      expect(ESLEventListener.descriptors(obj).length).toEqual(1);
-      expect(ESLEventListener.descriptors(obj)[0]).toEqual(obj.onEvent);
-    });
-  });
-
   describe('create', () => {
     test('one by string', () => {
       const host = document.createElement('div');

--- a/src/modules/esl-utils/dom/events/test/utils.test.ts
+++ b/src/modules/esl-utils/dom/events/test/utils.test.ts
@@ -19,6 +19,33 @@ describe('dom/events: EventUtils', () => {
     });
   });
 
+  describe('descriptors', () => {
+    test('basic test 1', () => {
+      const fn1 = () => undefined;
+      const fn2 = () => undefined;
+      fn1.event = fn2.event = 'test';
+
+      const obj = {onClick: fn1};
+      const proto = {onEvent: fn2};
+      Object.setPrototypeOf(obj, proto);
+
+      const desc = EventUtils.descriptors(obj);
+      expect(Array.isArray(desc)).toBe(true);
+      expect(desc.includes(fn1));
+      expect(desc.includes(fn2));
+    });
+    test('basic test 2', () => {
+      const obj: any = document.createElement('div');
+
+      expect(EventUtils.descriptors(obj)).toEqual([]);
+
+      obj.onEvent = Object.assign(() => undefined, {event: 'event', auto: true});
+
+      expect(EventUtils.descriptors(obj).length).toEqual(1);
+      expect(EventUtils.descriptors(obj)[0]).toEqual(obj.onEvent);
+    });
+  });
+
   describe('listeners', () => {
     const list = [
       {matches: jest.fn()},
@@ -50,29 +77,15 @@ describe('dom/events: EventUtils', () => {
 
   describe('subscribe', () => {
     const listener1 =
-      Object.assign(() => undefined, {auto: true, subscribe: jest.fn()});
-    const listener2 =
       Object.assign(() => undefined, {auto: false, subscribe: jest.fn()});
-
-    test('all', () => {
-      const host = {};
-      jest.spyOn(ESLEventListener, 'descriptors').mockReturnValue([listener1, listener2] as any);
-      const createMock =
-        jest.spyOn(ESLEventListener, 'create').mockImplementation((el, cb, desc) => [desc] as any);
-
-      EventUtils.subscribe(host as any);
-      expect(listener1.subscribe).toBeCalled();
-      expect(listener2.subscribe).not.toBeCalled();
-      expect(createMock).toBeCalledWith(host, expect.anything(), expect.anything());
-    });
 
     test('decorated handler', () => {
       const host = {};
       const createMock =
         jest.spyOn(ESLEventListener, 'create').mockImplementation((el, cb, desc) => [desc] as any);
 
-      EventUtils.subscribe(host as any, listener2);
-      expect(listener2.subscribe).toBeCalled();
+      EventUtils.subscribe(host as any, listener1);
+      expect(listener1.subscribe).toBeCalled();
       expect(createMock).toBeCalledWith(host, expect.anything(), expect.anything());
     });
 

--- a/src/modules/esl-utils/misc/object/compare.ts
+++ b/src/modules/esl-utils/misc/object/compare.ts
@@ -16,15 +16,17 @@ export function isEqual(obj1: any, obj2: any): boolean {
 /** @deprecated alias for `isEqual` method */
 export const deepCompare = isEqual;
 
+/** Check if arr and arr mask has intersection */
+function isIntersect(arrObj: any[], arrMask: any[], comparer: (a: any, b: any) => boolean): boolean {
+  return arrMask.every((key) => arrObj.some((itm) => comparer(itm, key)));
+}
+
 /**
  * Checks if all keys presented in the `mask` are equal to the `obj` keys
  * Note: array order is not taken into account and uses intersection strategy
  */
-export function isSimilar(obj: any, mask: any): boolean {
-  if (Array.isArray(obj)) {
-    if (Array.isArray(mask)) return mask.every((key) => isSimilar(obj, key));
-    return obj.some((key) => isSimilar(key, mask));
-  }
+export function isSimilar(obj: any, mask: any, deep: boolean = true): boolean {
+  if (Array.isArray(obj) && Array.isArray(mask)) return isIntersect(obj, mask, deep ? isSimilar : Object.is);
   if (!isObject(obj) || !isObject(mask)) return Object.is(obj, mask);
-  return Object.keys(mask).every((key: string) => isSimilar(obj[key], mask[key]));
+  return Object.keys(mask).every((key: string) => (deep ? isSimilar : Object.is)(obj[key], mask[key]));
 }

--- a/src/modules/esl-utils/misc/object/test/compare.test.ts
+++ b/src/modules/esl-utils/misc/object/test/compare.test.ts
@@ -40,6 +40,8 @@ describe('misc/object: compare', () => {
   });
 
   describe('isSimilar', () => {
+    const obj = {};
+
     test.each([
       [null, null],
       [NaN, NaN],
@@ -54,9 +56,8 @@ describe('misc/object: compare', () => {
       [{a: 1, c: Infinity}, {c: Infinity}],
       [{a: {b: {c: 1}}}, {a: {b: {c: 1}}}],
       [[{a: 1}, {b: ''}], [{a: 1}]],
-
-      [[1, 2, 3, 4, 5, 6], [3, 2]]
-    ])('%p should be similar to %p', (a: any, b: any) => expect(isSimilar(a, b)).toBe(true));
+      [[1, 2, 3, 4, 5], [3, 2]]
+    ])('%p should be deep similar to %p', (a: any, b: any) => expect(isSimilar(a, b)).toBe(true));
 
     test.each([
       [undefined, null],
@@ -68,8 +69,35 @@ describe('misc/object: compare', () => {
       [{a: null, b: 1}, {a: {}}],
       [{a: {c: {b: 1}, d: 1}}, {a: {b: {c: 1}}}],
 
+      [[3], 3],
       [[], [1]],
       [[1], [1, 2]]
-    ])('%p should not be similar to %p', (a: any, b: any) => expect(isSimilar(a, b)).toBe(false));
+    ])('%p should not be deep similar to %p', (a: any, b: any) => expect(isSimilar(a, b)).toBe(false));
+
+    test.each([
+      [null, null],
+      [NaN, NaN],
+      ['', ''],
+      [{}, {}],
+
+      [{a: 1}, {a: 1}],
+      [{a: obj}, {a: obj}],
+      [{a: 1, c: Infinity}, {c: Infinity}],
+
+      [[obj, {b: ''}], [obj]]
+    ])('%p should be flat similar to %p', (a: any, b: any) => expect(isSimilar(a, b, false)).toBe(true));
+
+    test.each([
+      [null, undefined],
+      [1, 2],
+      ['a', 'b'],
+
+      [{a: 1}, {a: 2}],
+      [{a: {b: 2}}, {a: {b: 2}}],
+      [{a: 1, c: {}}, {c: {}}],
+
+      [[{a: 1}, {b: ''}], [{a: 1}]],
+      [[{a: {}}, {b: ''}], [{a: {}}]]
+    ])('%p should not be flat similar to %p', (a: any, b: any) => expect(isSimilar(a, b, false)).toBe(false));
   });
 });


### PR DESCRIPTION
 Preparation for mixin components, see https://github.com/exadel-inc/esl/pull/816/commits/33ce7aa5c3625266b3900ed8d88f012f847945a6 

 - `ESLEventListener.descriptors` moved to `EventUtils.descriptors`
 - add ability to subscribe handler with additional descriptor data
 - remove subscribe all descriptors functionality