### PR TITLE
fix(esl-utils): rename some event/misc utils

### DIFF
--- a/src/modules/draft/esl-carousel/plugin/esl-carousel-touch.plugin.ts
+++ b/src/modules/draft/esl-carousel/plugin/esl-carousel-touch.plugin.ts
@@ -1,6 +1,6 @@
 import {ExportNs} from '../../../esl-utils/environment/export-ns';
 import {DeviceDetector} from '../../../esl-utils/environment/device-detector';
-import {touchPoint} from '../../../esl-utils/dom/events';
+import {getTouchPoint} from '../../../esl-utils/dom/events';
 import {ESLCarouselPlugin} from './esl-carousel-plugin';
 
 import type {Point} from '../../../esl-utils/dom/events';
@@ -39,7 +39,7 @@ export class ESLCarouselTouchPlugin extends ESLCarouselPlugin {
       return;
     }
     this.isTouchStarted = true;
-    this.startPoint = touchPoint(event);
+    this.startPoint = getTouchPoint(event);
   };
 
   onTouchMove = (event: TouchEvent | PointerEvent) => {
@@ -53,7 +53,7 @@ export class ESLCarouselTouchPlugin extends ESLCarouselPlugin {
 
   onTouchEnd = (event: TouchEvent | PointerEvent) => {
     if (!this.isTouchStarted) return;
-    const point = touchPoint(event);
+    const point = getTouchPoint(event);
     const offset = {
       x: point.x - this.startPoint.x,
       y: point.y - this.startPoint.y

--- a/src/modules/esl-scrollbar/core/esl-scrollbar.ts
+++ b/src/modules/esl-scrollbar/core/esl-scrollbar.ts
@@ -3,7 +3,7 @@ import {ESLBaseElement, attr, boolAttr} from '../../esl-base-element/core';
 import {bind} from '../../esl-utils/decorators/bind';
 import {ready} from '../../esl-utils/decorators/ready';
 import {rafDecorator} from '../../esl-utils/async/raf';
-import {isMouseEvent, isTouchEvent, touchPoint, offsetPoint} from '../../esl-utils/dom/events';
+import {isMouseEvent, isTouchEvent, getTouchPoint, getOffsetPoint} from '../../esl-utils/dom/events';
 import {isRelativeNode} from '../../esl-utils/dom/traversing';
 import {TraversingQuery} from '../../esl-traversing-query/core';
 import {RTLUtils} from '../../esl-utils/dom/rtl';
@@ -244,8 +244,8 @@ export class ESLScrollbar extends ESLBaseElement {
   /** Returns position from MouseEvent coordinates (not normalized) */
   public toPosition(event: MouseEvent | TouchEvent): number {
     const {horizontal, thumbOffset, trackOffset} = this;
-    const point = touchPoint(event);
-    const offset = offsetPoint(this.$scrollbarTrack);
+    const point = getTouchPoint(event);
+    const offset = getOffsetPoint(this.$scrollbarTrack);
     const pointPosition = horizontal ? point.x - offset.x : point.y - offset.y;
     const freeTrackArea = trackOffset - thumbOffset; // size of free track px
     const clickPositionNoOffset = pointPosition - thumbOffset / 2;
@@ -258,7 +258,7 @@ export class ESLScrollbar extends ESLBaseElement {
   protected _onPointerDown(event: MouseEvent | TouchEvent): void {
     this._initialPosition = this.position;
     this._pointerPosition = this.toPosition(event);
-    const point = touchPoint(event);
+    const point = getTouchPoint(event);
     this._initialMousePosition = this.horizontal ? point.x : point.y;
 
     if (event.target === this.$scrollbarThumb) {
@@ -301,7 +301,7 @@ export class ESLScrollbar extends ESLBaseElement {
 
   /** Sets position on drag */
   protected _onPointerDrag(event: MouseEvent | TouchEvent): void {
-    const point = touchPoint(event);
+    const point = getTouchPoint(event);
     const mousePosition = this.horizontal ? point.x : point.y;
     const positionChange = mousePosition - this._initialMousePosition;
     const scrollableAreaHeight = this.trackOffset - this.thumbOffset;

--- a/src/modules/esl-utils/dom/events/misc.ts
+++ b/src/modules/esl-utils/dom/events/misc.ts
@@ -7,18 +7,18 @@ export const isTouchEvent = (event: Event): event is TouchEvent => window.TouchE
 /** Checks if the passed event is {@link PointerEvent} */
 export const isPointerEvent = (event: Event): event is PointerEvent => window.PointerEvent && event instanceof PointerEvent;
 
-/** Gets the original CustomEvent source */
-export const getCompositeTarget = (e: CustomEvent): EventTarget | null => {
-  const targets = (e.composedPath && e.composedPath());
-  return targets ? targets[0] : e.target;
-};
-
 const PASSIVE_EVENTS = ['wheel', 'mousewheel', 'touchstart', 'touchmove'];
 /**
  * @returns true if the passed event should be passive by default
  * @see https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md
  */
 export const isPassiveByDefault = (event: string): boolean => PASSIVE_EVENTS.includes(event);
+
+/** Gets the original CustomEvent source */
+export const getCompositeTarget = (e: CustomEvent): EventTarget | null => {
+  const targets = (e.composedPath && e.composedPath());
+  return targets ? targets[0] : e.target;
+};
 
 /** Object that describes coordinates */
 export interface Point {
@@ -27,7 +27,7 @@ export interface Point {
 }
 
 /** @returns touch point coordinates of {@link TouchEvent} or {@link PointerEvent} */
-export const touchPoint = (event: TouchEvent | PointerEvent | MouseEvent): Point => {
+export const getTouchPoint = (event: TouchEvent | PointerEvent | MouseEvent): Point => {
   const source = isTouchEvent(event) ? event.changedTouches[0] : event;
   return {
     x: source.pageX,
@@ -36,7 +36,7 @@ export const touchPoint = (event: TouchEvent | PointerEvent | MouseEvent): Point
 };
 
 /** @returns element offset point coordinates */
-export const offsetPoint = (el: Element): Point => {
+export const getOffsetPoint = (el: Element): Point => {
   const props = el.getBoundingClientRect();
   const y = props.top + window.scrollY;
   const x = props.left + window.scrollX;

--- a/src/modules/esl-utils/dom/events/test/misc.test.ts
+++ b/src/modules/esl-utils/dom/events/test/misc.test.ts
@@ -3,8 +3,8 @@ import {
   isTouchEvent,
   isPointerEvent,
   isPassiveByDefault,
-  touchPoint,
-  offsetPoint,
+  getTouchPoint,
+  getOffsetPoint,
   getCompositeTarget
 } from '../misc';
 
@@ -82,7 +82,7 @@ describe('dom/events: misc', () => {
           pageY,
         } as any]
       });
-      expect(touchPoint(event)).toEqual({x: pageX, y: pageY});
+      expect(getTouchPoint(event)).toEqual({x: pageX, y: pageY});
     });
 
     test('returns normalized data from PointerEvent object', () => {
@@ -91,7 +91,7 @@ describe('dom/events: misc', () => {
         pageX,
         pageY
       });
-      expect(touchPoint(event)).toEqual({x: pageX, y: pageY});
+      expect(getTouchPoint(event)).toEqual({x: pageX, y: pageY});
     });
   });
 
@@ -109,7 +109,7 @@ describe('dom/events: misc', () => {
         scrollY: 200,
       });
 
-      expect(offsetPoint(elem)).toEqual({
+      expect(getOffsetPoint(elem)).toEqual({
         x:  (boundingClientRect.left + window.scrollX),
         y:  (boundingClientRect.top + window.scrollY)
       });

--- a/src/modules/esl-utils/dom/test/events.test.ts
+++ b/src/modules/esl-utils/dom/test/events.test.ts
@@ -1,11 +1,11 @@
-import {EventUtils, isMouseEvent, isTouchEvent, offsetPoint, touchPoint} from '../events';
+import {EventUtils, isMouseEvent, isTouchEvent, getOffsetPoint, getTouchPoint} from '../events';
 
 describe('dom/events: availability', () => {
   test.each([
     isMouseEvent,
     isTouchEvent,
-    touchPoint,
-    offsetPoint,
+    getTouchPoint,
+    getOffsetPoint,
 
     EventUtils.dispatch,
     EventUtils.listeners,


### PR DESCRIPTION
BREAKING CHANGE: rename `offsetPoint` to `getOffsetPoint` and `touchPoint` to `getTouchPoint`