### PR TITLE
tech: event namespace (First step #916)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -308,7 +308,7 @@ renamed to `ESLPanelGroup.noAnimate` (`no-animate` attribute)
 ### Features
 
 * **esl-panel-group:** ability to define params for child panels requests ([08cf513](https://github.com/exadel-inc/esl/commit/08cf51385cae2514b220b9950d53d0afa4b1b5d3))
-* **esl-panel-group:** dispatch change:mode event ([8d41dbd](https://github.com/exadel-inc/esl/commit/8d41dbd69ac703858f1dd8d43ece748da58780f1))
+* **esl-panel-group:** dispatch esl:change:mode event ([8d41dbd](https://github.com/exadel-inc/esl/commit/8d41dbd69ac703858f1dd8d43ece748da58780f1))
 * **esl-panel-group:** make animation disabled on transform by default ([1815b00](https://github.com/exadel-inc/esl/commit/1815b006a6decfc91b275b5c28ae9da17b1bf311))
 * **esl-panel-group:** rename `view` attribute to `current-mode`; extend mode class API ([52188fe](https://github.com/exadel-inc/esl/commit/52188fe43457d2f362cd7cca0a126cbf01ffb9c9))
 * **esl-toggleable:** add id auto-creation feature for toggleable instances ([eaf02dc](https://github.com/exadel-inc/esl/commit/eaf02dc490dd0c92b6b9bbdf758769eeba15d62d))
@@ -334,7 +334,7 @@ renamed to `ESLPanelGroup.noAnimate` (`no-animate` attribute)
 
 ### Features
 
-* **esl-panel-group:** dispatch change:mode event ([8d41dbd](https://github.com/exadel-inc/esl/commit/8d41dbd69ac703858f1dd8d43ece748da58780f1))
+* **esl-panel-group:** dispatch esl:change:mode event ([8d41dbd](https://github.com/exadel-inc/esl/commit/8d41dbd69ac703858f1dd8d43ece748da58780f1))
 
 ## [3.10.1-beta.1](https://github.com/exadel-inc/esl/compare/v3.10.0...v3.10.1-beta.1) (2021-12-22)
 

--- a/src/modules/draft/esl-carousel/core/esl-carousel.ts
+++ b/src/modules/draft/esl-carousel/core/esl-carousel.ts
@@ -117,7 +117,7 @@ export class ESLCarousel extends ESLBaseElement {
       }
     };
 
-    const approved = this.$$fire('slide:change', eventDetails);
+    const approved = this.$$fire('esl:slide:change', eventDetails);
 
     if (this._view && approved && this.firstIndex !== nextIndex) {
       this._view.goTo(nextIndex, direction);
@@ -140,7 +140,7 @@ export class ESLCarousel extends ESLBaseElement {
       }
     }
 
-    this.$$fire('slide:changed', eventDetails);
+    this.$$fire('esl:slide:changed', eventDetails);
   }
 
   public prev() {

--- a/src/modules/esl-base-element/README.md
+++ b/src/modules/esl-base-element/README.md
@@ -37,7 +37,7 @@ Attributes:
 
 - `$$cls` - check or change element CSS classes (uses CSSClassUtils) 
 - `$$attr` - check or change element attributes
-- `$$fire` - dispatch event with `esl:` prefix
+- `$$fire` - dispatch event
 
 - `$$on` - subscribe on event manually or subscribe decorated method
 - `$$off` - unsubscribe from event manually or unsubscribe decorated method

--- a/src/modules/esl-base-element/core/esl-base-element.ts
+++ b/src/modules/esl-base-element/core/esl-base-element.ts
@@ -86,7 +86,7 @@ export abstract class ESLBaseElement extends HTMLElement {
    * @param eventInit - custom event init. See {@link CustomEventInit}
    */
   public $$fire(eventName: string, eventInit?: CustomEventInit): boolean {
-    return EventUtils.dispatch(this, 'esl:' + eventName, eventInit);
+    return EventUtils.dispatch(this, eventName, eventInit);
   }
 
   /**

--- a/src/modules/esl-base-element/core/esl-mixin-element.ts
+++ b/src/modules/esl-base-element/core/esl-mixin-element.ts
@@ -110,7 +110,7 @@ export class ESLMixinElement implements AttributeTarget {
    * @param eventInit - custom event init. See {@link CustomEventInit}
    */
   public $$fire(eventName: string, eventInit?: CustomEventInit): boolean {
-    return EventUtils.dispatch(this.$host, 'esl:' + eventName, eventInit);
+    return EventUtils.dispatch(this.$host, eventName, eventInit);
   }
 
   /** Returns mixin instance by element */

--- a/src/modules/esl-base-element/test/element.test.ts
+++ b/src/modules/esl-base-element/test/element.test.ts
@@ -77,14 +77,14 @@ describe('ESLBaseElement', () => {
     });
 
     test('$$fire', (done) => {
-      el.addEventListener('esl:testevent', (e) => {
+      el.addEventListener('testevent', (e) => {
         expect(e).toBeInstanceOf(CustomEvent);
         done();
       }, {once: true});
       el.$$fire('testevent');
     }, 10);
     test('$$fire - bubbling', (done) => {
-      document.addEventListener('esl:testevent', (e) => {
+      document.addEventListener('testevent', (e) => {
         expect(e).toBeInstanceOf(CustomEvent);
         done();
       }, {once: true});

--- a/src/modules/esl-image/core/esl-image.ts
+++ b/src/modules/esl-image/core/esl-image.ts
@@ -290,8 +290,8 @@ export class ESLImage extends ESLBaseElement {
     this.toggleAttribute('loaded', successful);
     this.toggleAttribute('error', !successful);
     this.toggleAttribute('ready', true);
-    this.$$fire(successful ? 'load' : 'error');
-    this.$$fire('ready');
+    this.$$fire(successful ? 'load' : 'error', {bubbles: false});
+    this.$$fire('ready', {bubbles: false});
   }
 
   public updateContainerClasses(): void {
@@ -301,10 +301,6 @@ export class ESLImage extends ESLBaseElement {
 
     const targetEl = TraversingQuery.first(this.containerClassTarget, this) as HTMLElement;
     targetEl && CSSClassUtils.toggle(targetEl, cls, state);
-  }
-
-  public $$fire(eventName: string, eventInit: CustomEventInit = {bubbles: false}): boolean {
-    return EventUtils.dispatch(this, eventName, eventInit);
   }
 
   public static isEmptyImage(src: string): boolean {

--- a/src/modules/esl-panel-group/core/esl-panel-group.ts
+++ b/src/modules/esl-panel-group/core/esl-panel-group.ts
@@ -108,7 +108,7 @@ export class ESLPanelGroup extends ESLBaseElement {
     this.reset();
 
     if (prevMode !== currentMode) {
-      this.$$fire('change:mode', {detail: {prevMode, currentMode}});
+      this.$$fire('esl:change:mode', {detail: {prevMode, currentMode}});
     }
   }
 
@@ -234,7 +234,7 @@ export class ESLPanelGroup extends ESLBaseElement {
     CSSClassUtils.remove(this, this.animationClass);
 
     if (silent) return;
-    this.$activePanels.forEach((panel) => panel.$$fire('after:show'));
+    this.$activePanels.forEach((panel) => panel.$$fire('esl:after:show'));
   }
 
   /** Process {@link ESLPanel} pre-show event */

--- a/src/modules/esl-panel/core/esl-panel.ts
+++ b/src/modules/esl-panel/core/esl-panel.ts
@@ -125,7 +125,7 @@ export class ESLPanel extends ESLToggleable {
     this.clearAnimation();
     // Prevent fallback calls from being tracked
     if (!animating) return;
-    this.$$fire(this.open ? 'after:show' : 'after:hide');
+    this.$$fire(this.open ? 'esl:after:show' : 'esl:after:hide');
   }
 
   /** Clear animation properties */

--- a/src/modules/esl-scrollbar/core/esl-scrollbar.ts
+++ b/src/modules/esl-scrollbar/core/esl-scrollbar.ts
@@ -216,7 +216,7 @@ export class ESLScrollbar extends ESLBaseElement {
 
   /** Updates thumb size and position */
   public update(): void {
-    this.$$fire('change:scroll', {bubbles: false});
+    this.$$fire('esl:change:scroll', {bubbles: false});
     if (!this.$scrollbarThumb || !this.$scrollbarTrack) return;
     const thumbSize = this.trackOffset * this.thumbSize;
     const thumbPosition = (this.trackOffset - thumbSize) * this.position;

--- a/src/modules/esl-toggleable/core/esl-toggleable.ts
+++ b/src/modules/esl-toggleable/core/esl-toggleable.ts
@@ -113,7 +113,7 @@ export class ESLToggleable extends ESLBaseElement {
         this.toggle(this.open, {initiator: 'attribute', showDelay: 0, hideDelay: 0});
         break;
       case 'group':
-        this.$$fire('change:group',  {
+        this.$$fire('esl:change:group',  {
           detail: {oldGroupName: oldVal, newGroupName: newVal}
         });
         break;
@@ -197,20 +197,20 @@ export class ESLToggleable extends ESLBaseElement {
   /** Actual show task to execute by toggleable task manger ({@link DelayedTask} out of the box) */
   protected showTask(params: ToggleableActionParams): void {
     if (!params.force && this.open) return;
-    if (!params.silent && !this.$$fire('before:show', {detail: {params}})) return;
+    if (!params.silent && !this.$$fire('esl:before:show', {detail: {params}})) return;
     this.activator = params.activator;
     this.open = true;
     this.onShow(params);
-    if (!params.silent) this.$$fire('show', {detail: {params}, cancelable: false});
+    if (!params.silent) this.$$fire('esl:show', {detail: {params}, cancelable: false});
   }
   /** Actual hide task to execute by toggleable task manger ({@link DelayedTask} out of the box) */
   protected hideTask(params: ToggleableActionParams): void {
     if (!params.force && !this.open) return;
-    if (!params.silent && !this.$$fire('before:hide', {detail: {params}})) return;
+    if (!params.silent && !this.$$fire('esl:before:hide', {detail: {params}})) return;
     this.open = false;
     this.onHide(params);
     this.bindOutsideEventTracking(false);
-    if (!params.silent) this.$$fire('hide', {detail: {params}, cancelable: false});
+    if (!params.silent) this.$$fire('esl:hide', {detail: {params}, cancelable: false});
   }
 
   /**
@@ -222,7 +222,7 @@ export class ESLToggleable extends ESLBaseElement {
     CSSClassUtils.add(this, this.activeClass);
     CSSClassUtils.add(document.body, this.bodyClass, this);
     this.updateA11y();
-    this.$$fire('refresh'); // To notify other components about content change
+    this.$$fire('esl:refresh'); // To notify other components about content change
   }
 
   /**

--- a/src/modules/esl-trigger/core/esl-trigger.ts
+++ b/src/modules/esl-trigger/core/esl-trigger.ts
@@ -196,7 +196,7 @@ export class ESLTrigger extends ESLBaseElement {
   protected _onTargetStateChange(originalEvent?: Event): void {
     if (!this.updateState()) return;
     const detail = {active: this.active, originalEvent};
-    this.$$fire('change:active', {detail});
+    this.$$fire('esl:change:active', {detail});
   }
 
   /** Handles `click` event */


### PR DESCRIPTION
`$$fire` lo longer adds `esl:` prefix to event names