### PR TITLE
feat(esl-popup): add configurable rootMargin for the popup activator observer

### DIFF
--- a/pages/views/examples/footnotes.njk
+++ b/pages/views/examples/footnotes.njk
@@ -121,7 +121,7 @@ aside:
           <esl-panel class="esl-d-accordion-panel">
             <div class="esl-d-accordion-body">
               {{ lorem.paragraphs(7) }}
-              <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore <esl-note>I am note 3 from accordion</esl-note> aliqua. Donec massa sapien faucibus et molestie ac. Mi sit amet mauris commodo <esl-note>I am note 4 from accordion</esl-note> quis imperdiet massa. Viverra nibh cras pulvinar mattis nunc sed blandit. In nisl nisi scelerisque eu. Vel turpis nunc eget lorem dolor sed. Nisl pretium fusce id velit. Quam id leo in vitae turpis massa sed. Mauris sit amet. Ut aliquam purus sit amet luctus venenatis lectus magna.</p>
+              <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore <esl-note intersection-margin="-90px 0px -90px 0px">I am note 3 from accordion</esl-note> aliqua. Donec massa sapien faucibus et molestie ac. Mi sit amet mauris commodo <esl-note intersection-margin="-10%">I am note 4 from accordion</esl-note> quis imperdiet massa. Viverra nibh cras pulvinar mattis nunc sed blandit. In nisl nisi scelerisque eu. Vel turpis nunc eget lorem dolor sed. Nisl pretium fusce id velit. Quam id leo in vitae turpis massa sed. Mauris sit amet. Ut aliquam purus sit amet luctus venenatis lectus magna.</p>
             </div>
           </esl-panel>
         </div>

--- a/src/modules/esl-footnotes/core/esl-note.ts
+++ b/src/modules/esl-footnotes/core/esl-note.ts
@@ -53,6 +53,9 @@ export class ESLNote extends ESLBaseElement {
   /** Target to container element {@link TraversingQuery} to define bounds of tooltip visibility (window by default) */
   @attr() public container: string;
 
+  /** margin around the element that is used as the viewport for checking the visibility of the note tooltip */
+  @attr({defaultValue: '0px'})  public intersectionMargin: string;
+
   protected _$footnotes: ESLFootnotes | null;
   protected _index: number;
 
@@ -215,7 +218,8 @@ export class ESLNote extends ESLBaseElement {
       initiator: 'note',
       activator: this,
       containerEl,
-      html: this.html
+      html: this.html,
+      intersectionMargin: this.intersectionMargin
     }, ...params);
   }
 

--- a/src/modules/esl-popup/core/esl-popup.ts
+++ b/src/modules/esl-popup/core/esl-popup.ts
@@ -43,6 +43,8 @@ export interface PopupActionParams extends ToggleableActionParams {
   offsetTrigger?: number;
   /** offset in pixels from the edges of the container (or window if the container is not defined) */
   offsetContainer?: number;
+  /** margin around the element that is used as the viewport for checking the visibility of the popup activator */
+  intersectionMargin?: string;
   /** Target to container element to define bounds of popups visibility */
   container?: string;
   /** Container element that defines bounds of popups visibility (is not taken into account if the container attr is set on popup) */
@@ -66,6 +68,7 @@ export class ESLPopup extends ESLToggleable {
   protected _offsetContainer: number;
   protected _deferredUpdatePosition = rafDecorator(() => this._updatePosition());
   protected _activatorObserver: ActivatorObserver;
+  protected _intersectionMargin: string;
   protected _intersectionRatio: IntersectionRatioRect = {};
   protected _updateLoopID: number;
 
@@ -100,7 +103,8 @@ export class ESLPopup extends ESLToggleable {
   /** Default params to merge into passed action params */
   @jsonAttr<PopupActionParams>({defaultValue: {
     offsetTrigger: 3,
-    offsetContainer: 15
+    offsetContainer: 15,
+    intersectionMargin: '0px'
   }})
   public defaultParams: PopupActionParams;
 
@@ -190,6 +194,7 @@ export class ESLPopup extends ESLToggleable {
     this._containerEl = params.containerEl;
     this._offsetTrigger = params.offsetTrigger || 0;
     this._offsetContainer = params.offsetContainer || 0;
+    this._intersectionMargin = params.intersectionMargin || '0px';
 
     this.style.visibility = 'hidden'; // eliminates the blinking of the popup at the previous position
 
@@ -290,7 +295,7 @@ export class ESLPopup extends ESLToggleable {
 
     if (!this.disableActivatorObservation) {
       const options = {
-        rootMargin: '0px',
+        rootMargin: this._intersectionMargin,
         threshold: range(9, (x) => x / 8)
       } as IntersectionObserverInit;
 


### PR DESCRIPTION
In the scope of this PR:
 - add intersectionMargin param to esl-popup to configure rootMargin for the popup activator observer
 - add intersectionMargin attribute to esl-note to configure and transfer it to esl-tooltip
