### PR TITLE
Feat(esl-trigger): add aria-label support

### DIFF
--- a/pages/views/examples/toggleable.njk
+++ b/pages/views/examples/toggleable.njk
@@ -34,9 +34,9 @@ aside:
     </div>
     <p>Triggers</p>
     <div class="btn-container">
-      <esl-trigger target="#toggleable1" mode="toggle" a11y-label="{active: 'collapse', inactive: 'expand'}" class="btn btn-sec-blue">Toggle</esl-trigger>
-      <esl-trigger target="#toggleable1" mode="show" a11y-label="{active: '', inactive: 'expand'}" class="btn btn-sec-blue">Show</esl-trigger>
-      <esl-trigger target="#toggleable1" mode="hide" a11y-label="{}" class="btn btn-sec-blue">Hide</esl-trigger>
+      <esl-trigger target="#toggleable1" mode="toggle" a11y-label-active a11y-label-inactive='expand' class="btn btn-sec-blue">Toggle</esl-trigger>
+      <esl-trigger target="#toggleable1" mode="show" a11y-label-active='collapse' class="btn btn-sec-blue">Show</esl-trigger>
+      <esl-trigger target="#toggleable1" mode="hide" class="btn btn-sec-blue">Hide</esl-trigger>
     </div>
   </div>
 </section>

--- a/pages/views/examples/toggleable.njk
+++ b/pages/views/examples/toggleable.njk
@@ -34,9 +34,9 @@ aside:
     </div>
     <p>Triggers</p>
     <div class="btn-container">
-      <esl-trigger target="#toggleable1" mode="toggle" class="btn btn-sec-blue">Toggle</esl-trigger>
-      <esl-trigger target="#toggleable1" mode="show" class="btn btn-sec-blue">Show</esl-trigger>
-      <esl-trigger target="#toggleable1" mode="hide" class="btn btn-sec-blue">Hide</esl-trigger>
+      <esl-trigger target="#toggleable1" mode="toggle" a11y-label="{active: 'collapse', inactive: 'expand'}" class="btn btn-sec-blue">Toggle</esl-trigger>
+      <esl-trigger target="#toggleable1" mode="show" a11y-label="{active: '', inactive: 'expand'}" class="btn btn-sec-blue">Show</esl-trigger>
+      <esl-trigger target="#toggleable1" mode="hide" a11y-label="{}" class="btn btn-sec-blue">Hide</esl-trigger>
     </div>
   </div>
 </section>

--- a/src/modules/esl-trigger/README.md
+++ b/src/modules/esl-trigger/README.md
@@ -28,7 +28,9 @@ ESLTrigger - a custom element, that allows to trigger ESLToggleable instances st
 
 - `a11y-target` - selector of inner target element to place aria attributes. Uses trigger itself if blank
 
-- `a11y-label` - values of aria-label for active/inactive state
+- `a11y-label-active` - value of aria-label for active state
+
+- `a11y-label-inactive` - value of aria-label for inactive state
 
 - `show-delay` - show delay value (number in ms or `none`)
 

--- a/src/modules/esl-trigger/README.md
+++ b/src/modules/esl-trigger/README.md
@@ -28,6 +28,8 @@ ESLTrigger - a custom element, that allows to trigger ESLToggleable instances st
 
 - `a11y-target` - selector of inner target element to place aria attributes. Uses trigger itself if blank
 
+- `a11y-label` - values of aria-label for active/inactive state
+
 - `show-delay` - show delay value (number in ms or `none`)
 
 - `hide-delay` - hide delay value (number in ms or `none`)

--- a/src/modules/esl-trigger/core/esl-trigger.shape.ts
+++ b/src/modules/esl-trigger/core/esl-trigger.shape.ts
@@ -27,8 +27,11 @@ export interface ESLTriggerTagShape<T extends ESLTrigger = ESLTrigger> extends E
 
   /** Define selector of inner target element to place aria attributes */
   'a11y-target'?: string;
-  /** Define value of aria-label for active/inactive state */
-  'a11y-label'?: {active: string; inactive: string;};
+
+  /** Define value of aria-label for active state */
+  'a11y-label-active'?: string;
+  /** Define value of aria-label for inactive state */
+  'a11y-label-inactive'?: string;
 
   /** Define show delay value */
   'show-delay'?: string | number;

--- a/src/modules/esl-trigger/core/esl-trigger.shape.ts
+++ b/src/modules/esl-trigger/core/esl-trigger.shape.ts
@@ -27,6 +27,8 @@ export interface ESLTriggerTagShape<T extends ESLTrigger = ESLTrigger> extends E
 
   /** Define selector of inner target element to place aria attributes */
   'a11y-target'?: string;
+  /** Define value of aria-label for active/inactive state */
+  'a11y-label'?: {active: string; inactive: string;};
 
   /** Define show delay value */
   'show-delay'?: string | number;

--- a/src/modules/esl-trigger/core/esl-trigger.ts
+++ b/src/modules/esl-trigger/core/esl-trigger.ts
@@ -1,5 +1,5 @@
 import {ExportNs} from '../../esl-utils/environment/export-ns';
-import {attr, boolAttr, ESLBaseElement} from '../../esl-base-element/core';
+import {attr, boolAttr, ESLBaseElement, jsonAttr} from '../../esl-base-element/core';
 import {bind} from '../../esl-utils/decorators/bind';
 import {ready} from '../../esl-utils/decorators/ready';
 import {parseNumber} from '../../esl-utils/misc/format';
@@ -11,6 +11,13 @@ import {ESLMediaQuery} from '../../esl-media-query/core';
 import {ESLToggleablePlaceholder} from '../../esl-toggleable/core';
 
 import type {ESLToggleable, ToggleableActionParams} from '../../esl-toggleable/core/esl-toggleable';
+
+export interface TriggerActionLabel {
+  /** Value of aria-label for active state */
+  active?: string;
+  /** Value of aria-label for inactive state */
+  inactive?: string;
+}
 
 @ExportNs('Trigger')
 export class ESLTrigger extends ESLBaseElement {
@@ -60,6 +67,9 @@ export class ESLTrigger extends ESLBaseElement {
    */
   @attr({defaultValue: '0'}) public hoverHideDelay: string;
 
+  /** Values of aria-label for active/inactive state */
+  @jsonAttr<TriggerActionLabel>({defaultValue: {}}) public a11yLabel: TriggerActionLabel;
+
   protected _$target: ESLToggleable | null;
 
   protected attributeChangedCallback(attrName: string): void {
@@ -81,6 +91,14 @@ export class ESLTrigger extends ESLBaseElement {
   /** Element target to setup aria attributes */
   public get $a11yTarget(): HTMLElement | null {
     return this.a11yTarget ? this.querySelector(this.a11yTarget) : this;
+  }
+
+  public get $a11yLabel(): string | null {
+    if (this.a11yLabel && Object.keys(this.a11yLabel).length) {
+      const label = this.$target?.open ? this.a11yLabel?.active : this.a11yLabel?.inactive;
+      return label ?? '';
+    }
+    return null;
   }
 
   /** Marker to allow track hover */
@@ -255,6 +273,7 @@ export class ESLTrigger extends ESLBaseElement {
     if (this.getAttribute('role') === 'button' && !this.hasAttribute('tabindex')) {
       this.setAttribute('tabindex', '0');
     }
+    typeof this.$a11yLabel === 'string' && this.setAttribute('aria-label', this.$a11yLabel);
   }
 
   /** Update aria attributes */
@@ -262,6 +281,7 @@ export class ESLTrigger extends ESLBaseElement {
     const target = this.$a11yTarget;
     if (!target) return;
 
+    typeof this.$a11yLabel === 'string' && this.setAttribute('aria-label', this.$a11yLabel);
     target.setAttribute('aria-expanded', String(this.active));
     if (this.$target && this.$target.id) {
       target.setAttribute('aria-controls', this.$target.id);

--- a/src/modules/esl-trigger/core/esl-trigger.ts
+++ b/src/modules/esl-trigger/core/esl-trigger.ts
@@ -1,5 +1,5 @@
 import {ExportNs} from '../../esl-utils/environment/export-ns';
-import {attr, boolAttr, ESLBaseElement, jsonAttr} from '../../esl-base-element/core';
+import {attr, boolAttr, ESLBaseElement} from '../../esl-base-element/core';
 import {bind} from '../../esl-utils/decorators/bind';
 import {ready} from '../../esl-utils/decorators/ready';
 import {parseNumber} from '../../esl-utils/misc/format';

--- a/src/modules/esl-trigger/core/esl-trigger.ts
+++ b/src/modules/esl-trigger/core/esl-trigger.ts
@@ -12,13 +12,6 @@ import {ESLToggleablePlaceholder} from '../../esl-toggleable/core';
 
 import type {ESLToggleable, ToggleableActionParams} from '../../esl-toggleable/core/esl-toggleable';
 
-export interface TriggerActionLabel {
-  /** Value of aria-label for active state */
-  active?: string;
-  /** Value of aria-label for inactive state */
-  inactive?: string;
-}
-
 @ExportNs('Trigger')
 export class ESLTrigger extends ESLBaseElement {
   public static is = 'esl-trigger';
@@ -51,6 +44,11 @@ export class ESLTrigger extends ESLBaseElement {
   /** Selector of inner target element to place aria attributes. Uses trigger itself if blank */
   @attr({defaultValue: ''}) public a11yTarget: string;
 
+  /** Value of aria-label for active state */
+  @attr({defaultValue: ''}) public a11yLabelActive: string;
+  /** Value of aria-label for inactive state */
+  @attr({defaultValue: ''}) public a11yLabelInactive: string;
+
   /** Show delay value */
   @attr({defaultValue: 'none'}) public showDelay: string;
   /** Hide delay value */
@@ -66,9 +64,6 @@ export class ESLTrigger extends ESLBaseElement {
    * Note: the value should be numeric in order to delay hover action triggers for correct handling on mobile browsers.
    */
   @attr({defaultValue: '0'}) public hoverHideDelay: string;
-
-  /** Values of aria-label for active/inactive state */
-  @jsonAttr<TriggerActionLabel>({defaultValue: {}}) public a11yLabel: TriggerActionLabel;
 
   protected _$target: ESLToggleable | null;
 
@@ -93,9 +88,10 @@ export class ESLTrigger extends ESLBaseElement {
     return this.a11yTarget ? this.querySelector(this.a11yTarget) : this;
   }
 
-  public get $a11yLabel(): string | null {
-    if (this.a11yLabel && Object.keys(this.a11yLabel).length) {
-      const label = this.$target?.open ? this.a11yLabel?.active : this.a11yLabel?.inactive;
+  /** Value to setup aria-label */
+  public get a11yLabel(): string | null {
+    if (this.a11yLabelActive || this.a11yLabelInactive) {
+      const label = this.$target?.open ? this.a11yLabelActive : this.a11yLabelInactive;
       return label ?? '';
     }
     return null;
@@ -273,7 +269,6 @@ export class ESLTrigger extends ESLBaseElement {
     if (this.getAttribute('role') === 'button' && !this.hasAttribute('tabindex')) {
       this.setAttribute('tabindex', '0');
     }
-    typeof this.$a11yLabel === 'string' && this.setAttribute('aria-label', this.$a11yLabel);
   }
 
   /** Update aria attributes */
@@ -281,7 +276,7 @@ export class ESLTrigger extends ESLBaseElement {
     const target = this.$a11yTarget;
     if (!target) return;
 
-    typeof this.$a11yLabel === 'string' && this.setAttribute('aria-label', this.$a11yLabel);
+    typeof this.a11yLabel === 'string' && this.setAttribute('aria-label', this.a11yLabel);
     target.setAttribute('aria-expanded', String(this.active));
     if (this.$target && this.$target.id) {
       target.setAttribute('aria-controls', this.$target.id);

--- a/src/modules/esl-trigger/core/esl-trigger.ts
+++ b/src/modules/esl-trigger/core/esl-trigger.ts
@@ -45,9 +45,9 @@ export class ESLTrigger extends ESLBaseElement {
   @attr({defaultValue: ''}) public a11yTarget: string;
 
   /** Value of aria-label for active state */
-  @attr({defaultValue: ''}) public a11yLabelActive: string;
+  @attr() public a11yLabelActive: string;
   /** Value of aria-label for inactive state */
-  @attr({defaultValue: ''}) public a11yLabelInactive: string;
+  @attr() public a11yLabelInactive: string;
 
   /** Show delay value */
   @attr({defaultValue: 'none'}) public showDelay: string;
@@ -90,11 +90,8 @@ export class ESLTrigger extends ESLBaseElement {
 
   /** Value to setup aria-label */
   public get a11yLabel(): string | null {
-    if (this.a11yLabelActive || this.a11yLabelInactive) {
-      const label = this.$target?.open ? this.a11yLabelActive : this.a11yLabelInactive;
-      return label ?? '';
-    }
-    return null;
+    if (!this.$target) return null;
+    return (this.$target.open ? this.a11yLabelActive : this.a11yLabelInactive) || null;
   }
 
   /** Marker to allow track hover */
@@ -276,7 +273,7 @@ export class ESLTrigger extends ESLBaseElement {
     const target = this.$a11yTarget;
     if (!target) return;
 
-    typeof this.a11yLabel === 'string' && this.setAttribute('aria-label', this.a11yLabel);
+    this.a11yLabel ? target.setAttribute('aria-label', this.a11yLabel) : target.removeAttribute('aria-label');
     target.setAttribute('aria-expanded', String(this.active));
     if (this.$target && this.$target.id) {
       target.setAttribute('aria-controls', this.$target.id);


### PR DESCRIPTION
In the scope of this PR I made ability to define values of aria-label for both esl-trigger states via `a11y-label`.
Example:
 a11y-label="{active: 'collapse', inactive: 'expand'}"