### PR TITLE
feat(esl-utils): ScrollIntoView new implementation

### DIFF
--- a/src/modules/esl-utils/dom/scroll.ts
+++ b/src/modules/esl-utils/dom/scroll.ts
@@ -1,4 +1,4 @@
-import {tryUntil} from '../async/promise';
+import {createDeferred} from '../async/promise';
 import {getNodeName, getParentNode} from './api';
 
 export type ScrollStrategy = 'none' | 'native' | 'pseudo';
@@ -99,6 +99,55 @@ export function isScrollParent(element: Element): boolean {
   return /auto|scroll|overlay|hidden/.test(overflow + overflowY + overflowX);
 }
 
+
+interface ScrollIntoViewOptionsExtended extends ScrollIntoViewOptions {
+  offsetTop?: number;
+  offsetLeft?: number;
+}
+
+interface StepOptions {
+  deferred: any;
+  behavior: string;
+  el: Element;
+  top: number;
+  left: number;
+  startTime: number;
+  startTop: number;
+  startLeft: number;
+}
+
+interface OffsetParams {
+  setting: string;
+  start: number;
+  length: number;
+  frameStart: number;
+  frameLength: number;
+}
+
+interface OverflowParams {
+  scrollStart: number;
+  elementStart: number;
+}
+
+interface OverflowRecalcParams extends OverflowParams {
+  scrollLength: number;
+  frameLength: number;
+}
+
+interface Rectangle {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+interface Rectangle {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
 /**
  * This is a promise-based version of scrollIntoView().
  * Method scrolls the element's parent container such that the element on which
@@ -110,21 +159,142 @@ export function isScrollParent(element: Element): boolean {
  * @param element - element to be made visible to the user
  * @param options - scrollIntoView options
  */
-export function scrollIntoView(element: Element, options?: boolean | ScrollIntoViewOptions | undefined): Promise<boolean> {
-  let same = 0;
-  let lastLeft: number;
-  let lastTop: number;
-  const check = (): boolean => {
-    const {top, left} = element.getBoundingClientRect();
 
-    if (top !== lastTop || left !== lastLeft) {
-      same = 0;
-      lastTop = top;
-      lastLeft = left;
-    }
-    return same++ > 2;
-  };
+export function scrollIntoView(element: Element, options: boolean | ScrollIntoViewOptionsExtended = {block: 'start', inline: 'nearest'}): Promise<any> {
+  const scrollablesArr = getListScrollParents(element);
+  if (!scrollablesArr) return Promise.reject();
+  if (typeof options === 'boolean') {
+    options = (options ? {block: 'start', inline: 'nearest'} : {block: 'end', inline: 'nearest'}) as ScrollIntoViewOptionsExtended;
+  }
+  const optionsObj: ScrollIntoViewOptionsExtended = options;
+  const elementRect = getElementDefaultDimensions(element, options);
 
-  element.scrollIntoView(options);
-  return tryUntil(check, 333, 30); // will check top position every 30ms, but not more than 250 times (10s)
+  const startTime = Date.now();
+
+  const deferredArr = scrollablesArr.map((scrollable: Element) => {
+    const deferred = createDeferred<void>();
+    const newRect = calcNewRectangle(elementRect, scrollable, optionsObj);
+
+    const scrollTop = recalcWithoutOverflow({
+      scrollStart: elementRect.top + scrollable.scrollTop - newRect.top,
+      elementStart: newRect.top,
+      scrollLength: scrollable.scrollHeight,
+      frameLength: scrollable.clientHeight});
+
+    const scrollLeft = recalcWithoutOverflow({
+      scrollStart: elementRect.left + scrollable.scrollLeft - newRect.left,
+      elementStart: newRect.left,
+      scrollLength: scrollable.scrollWidth,
+      frameLength: scrollable.clientWidth});
+
+    step({
+      deferred,
+      behavior: optionsObj.behavior || 'auto',
+      el: scrollable,
+      top: scrollTop.scrollStart,
+      left: scrollLeft.scrollStart,
+      startTime,
+      startTop: scrollable.scrollTop,
+      startLeft: scrollable.scrollLeft
+    });
+
+    Object.assign(elementRect, {top: scrollTop.elementStart, left: scrollLeft.elementStart});
+
+    return deferred.promise;
+  }, []);
+
+  return Promise.all(deferredArr)
+    .then(() => {
+      const elRect = getElementDefaultDimensions(element, optionsObj);
+      if (Math.abs(elementRect.top - elRect.top) >= 2 && Math.abs(elementRect.left - elRect.left) >= 2) throw false;
+    });
+}
+
+/** Calculates element rectangle according to passed options */
+function calcNewRectangle(elRect: Rectangle, scrollable: Element, options: ScrollIntoViewOptionsExtended): Rectangle {
+  const frame = scrollable.getBoundingClientRect();
+  const left = frame.left + calcOffset({
+    setting: options.inline!,
+    start: elRect.left,
+    length: elRect.width,
+    frameStart: frame.left,
+    frameLength: scrollable.clientWidth});
+
+  const top = frame.top + calcOffset({
+    setting: options.block!,
+    start: elRect.top,
+    length: elRect.height,
+    frameStart: frame.top,
+    frameLength: scrollable.clientHeight});
+
+  return {left, top, width: elRect.width, height: elRect.height};
+}
+
+/** Returns element rectangle with margins */
+function getElementDefaultDimensions(element: Element, options: ScrollIntoViewOptionsExtended): Rectangle {
+  const elrect = element.getBoundingClientRect();
+  const style = window.getComputedStyle(element);
+
+  const marginWidth = parseFloat(style.marginLeft) + parseFloat(style.marginRight);
+  const marginHeight = parseFloat(style.marginTop) + parseFloat(style.marginBottom);
+
+  const top = elrect.top - parseFloat(style.marginTop) + (options.offsetTop || 0);
+  const left = elrect.left - parseFloat(style.marginLeft) + (options.offsetLeft || 0);
+
+  return {top, left, width: element.clientWidth + marginWidth, height: element.clientHeight + marginHeight};
+}
+
+/** Corrects calculated scroll and element position if it goes outside of frame */
+function recalcWithoutOverflow(obj: OverflowRecalcParams): OverflowParams {
+  if (obj.scrollStart > obj.scrollLength - obj.frameLength) {
+    const overflow = obj.scrollStart - (obj.scrollLength - obj.frameLength);
+    obj.elementStart += overflow;
+    obj.scrollStart -= overflow;
+  }
+
+  if (obj.scrollStart < 0 && obj.scrollStart < obj.scrollLength - obj.frameLength) {
+    obj.elementStart += obj.scrollStart;
+    obj.scrollStart = 0;
+  }
+
+  return {elementStart: obj.elementStart, scrollStart: obj.scrollStart};
+}
+
+/** Returns where element should be located on axis */
+function calcOffset(obj: OffsetParams): number {
+  const elementEnd = obj.start + obj.length;
+  const frameEnd = obj.frameStart + obj.frameLength;
+  if (obj.setting === 'center') return obj.frameLength / 2 - obj.length / 2;
+  if (obj.setting === 'end') return obj.frameLength - obj.length;
+  if (obj.setting === 'nearest') {
+    if (obj.start >= obj.frameStart && elementEnd <= frameEnd) return obj.start - obj.frameStart;
+    const middlePoint = (obj.start + elementEnd) / 2;
+    const distanceStart = Math.abs(obj.frameStart - middlePoint);
+    const distanceEnd = Math.abs(frameEnd - middlePoint);
+    return distanceStart < distanceEnd ? calcOffset(Object.assign(obj, {setting: 'start'})) : calcOffset(Object.assign(obj, {setting: 'end'}));
+  }
+  return 0;
+}
+
+function ease(time: number): number {
+  return 0.5 * (1 - Math.cos(Math.PI * time));
+}
+
+/** Looping function that scrolls element to passed context position */
+function step(context: StepOptions): Promise<any> | number {
+  const time = Date.now();
+  const duration = context.behavior === 'smooth' ? 1000 : 0;
+  let elapsed = (time - context.startTime) / duration;
+  elapsed = elapsed > 1 ? 1 : elapsed;
+  const value = ease(elapsed);
+
+  const currentLeft = context.startLeft + (context.left - context.startLeft) * (value);
+  const currentTop = context.startTop + (context.top - context.startTop) * (value);
+  context.el.scrollLeft = currentLeft;
+  context.el.scrollTop = currentTop;
+
+  if (currentLeft !== context.left || currentTop !== context.top) {
+    return window.requestAnimationFrame(() => step(context));
+  }
+  return context.deferred.resolve(true);
 }


### PR DESCRIPTION
In the scope of this PR i added promisified version for scrollIntoView().

Parameters:
element - the element which should become visible
options (Optional)

For boolean value:
If true, the top of the element will be aligned to the top of the visible area of the scrollable ancestor. Corresponds to scrollIntoViewOptions: {block: "start", inline: "nearest"}. This is the default value.
If false, the bottom of the element will be aligned to the bottom of the visible area of the scrollable ancestor. Corresponds to scrollIntoViewOptions: {block: "end", inline: "nearest"}.

For Object with the following properties:
behavior (Optional) - defines the transition animation. One of auto or smooth. Defaults to auto.
block (Optional) - defines vertical alignment. One of start, center, end, or nearest. Defaults to start.
inline (Optional) - defines horizontal alignment. One of start, center, end, or nearest. Defaults to nearest.
offsetTop (Optional) - defines vertical offset in pixels. Defaults is 0.
offsetLeft (Optional) - defines horizontal offset in pixels. Defaults is 0.