### PR TITLE
test(esl-utils): add tests to detect prototype pollution vulnerabilities

### DIFF
--- a/src/modules/esl-utils/misc/object/test/copy.test.ts
+++ b/src/modules/esl-utils/misc/object/test/copy.test.ts
@@ -61,4 +61,24 @@ describe('misc/object: copy', () => {
       expect(omit(inp, keys)).toEqual(out);
     });
   });
+
+  test('prototype pollution via __proto__', () => {
+    const maliciousPayload = '{"a": 1, "__proto__": {"polluted": true}}';
+    const a: any = {};
+    const copied: any = copy(JSON.parse(maliciousPayload));
+
+    expect(({} as any).polluted).not.toBe(true); // safe Plain Old Javascript Object
+    expect(a.polluted).not.toBe(true); // safe a input
+    expect(copied.polluted).toBe(true);
+  });
+
+  test('prototype pollution via constructor.prototype', () => {
+    const maliciousPayload = '{"a": 1, "constructor": {"prototype": {"polluted": true}}}';
+    const a: any = {};
+    const copied: any = copy(JSON.parse(maliciousPayload));
+
+    expect(({} as any).polluted).not.toBe(true); // safe Plain Old Javascript Object
+    expect(a.polluted).not.toBe(true); // safe a input
+    expect(copied.constructor.prototype.polluted).toBe(true);
+  });
 });

--- a/src/modules/esl-utils/misc/object/test/merge.test.ts
+++ b/src/modules/esl-utils/misc/object/test/merge.test.ts
@@ -69,4 +69,24 @@ describe('misc/object: deepMerge', () => {
     const result = args.pop();
     expect(deepMerge(...args)).toEqual(result);
   });
+
+  test('prototype pollution via __proto__', () => {
+    const maliciousPayload = '{"a": 1, "__proto__": {"polluted": true}}';
+    const a: any = {};
+    const merged: any = deepMerge({}, JSON.parse(maliciousPayload));
+
+    expect(({} as any).polluted).not.toBe(true); // safe Plain Old Javascript Object
+    expect(a.polluted).not.toBe(true); // safe a input
+    expect(merged.polluted).toBe(true);
+  });
+
+  test('prototype pollution via constructor.prototype', () => {
+    const maliciousPayload = '{"a": 1, "constructor": {"prototype": {"polluted": true}}}';
+    const a: any = {};
+    const merged: any = deepMerge({}, JSON.parse(maliciousPayload));
+
+    expect(({} as any).polluted).not.toBe(true); // safe Plain Old Javascript Object
+    expect(a.polluted).not.toBe(true); // safe a input
+    expect(merged.constructor.prototype.polluted).toBe(true);
+  });
 });


### PR DESCRIPTION
Added tests to detect prototype pollution vulnerabilities ([Analysis and Exploitation of Prototype Pollution attacks](https://blog.0daylabs.com/2019/02/15/prototype-pollution-javascript/))