### PR TITLE
feat(esl-utils): simplify and extend `@prop` decorator

### DIFF
--- a/src/modules/esl-utils/decorators/prop.ts
+++ b/src/modules/esl-utils/decorators/prop.ts
@@ -1,14 +1,9 @@
 /** Property configuration */
 export type OverrideDecoratorConfig = {
-  /** Value to set in the prototype */
-  value?: any;
-  /** To define mutable property */
-  readonly?: false;
-} | {
-  /** Value to set in the prototype */
-  value: any;
+  /** To define enumerable property */
+  enumerable?: boolean;
   /** To define readonly property */
-  readonly: true;
+  readonly?: boolean;
 };
 
 /**
@@ -21,17 +16,18 @@ export type OverrideDecoratorConfig = {
  * The class property initial value is a part of object creation, so it goes to the object itself,
  * while the @override value is defined on the prototype level.
  *
+ * @param value - value to setup in prototype
  * @param prototypeConfig - prototype property configuration
  */
-export function prop(prototypeConfig: OverrideDecoratorConfig = {}) {
+export function prop(value?: any, prototypeConfig: OverrideDecoratorConfig = {}) {
   return function (obj: any, name: string): void {
     if (Object.hasOwnProperty.call(obj, name)) {
       throw new TypeError('Can\'t override own property');
     }
     Object.defineProperty(obj, name, {
-      value: prototypeConfig.value,
+      value,
       writable: !prototypeConfig.readonly,
-      enumerable: true,
+      enumerable:  !prototypeConfig.enumerable,
       configurable: true
     });
   };

--- a/src/modules/esl-utils/decorators/test/prop.test.ts
+++ b/src/modules/esl-utils/decorators/test/prop.test.ts
@@ -18,11 +18,11 @@ describe('Decorator: @prop', () => {
 
   describe('Overriding @attr', () => {
     class TestElement extends TestBaseElement {
-      @prop({value: 'test'})
+      @prop('test')
       public field: string;
       @prop()
       public field4?: string;
-      @prop({value: 'test'})
+      @prop('test')
       public readonlyField: string;
     }
     customElements.define('attr-override-1', TestElement);
@@ -56,12 +56,12 @@ describe('Decorator: @prop', () => {
 
   describe('Overriding with a non writable', () => {
     class TestElement extends TestBaseElement {
-      @prop({value: 'test', readonly: true}) public field: string;
-      @prop({value: true, readonly: true}) public field2: boolean;
+      @prop('test', {enumerable: true, readonly: true}) public field: string;
+      @prop(true, {enumerable: true, readonly: true}) public field2: boolean;
     }
     class TestElement2 extends TestElement {
       @prop() public field: string = 'test2';
-      @prop({value: false}) public field2: boolean;
+      @prop(false) public field2: boolean;
     }
     customElements.define('attr-writable-override-1', TestElement);
     customElements.define('attr-writable-override-2', TestElement2);
@@ -85,7 +85,7 @@ describe('Decorator: @prop', () => {
 
   describe('Overriding @boolAttr', () => {
     class TestElement extends TestBaseElement {
-      @prop({value: true})
+      @prop(true)
       public field2: boolean;
     }
     customElements.define('bool-attr-override-1', TestElement);
@@ -107,7 +107,7 @@ describe('Decorator: @prop', () => {
 
   describe('Overriding @jsonAttr', () => {
     class TestElement extends TestBaseElement {
-      @prop({value: {a: 2}})
+      @prop({a: 2})
       public field3: {a: number};
     }
     customElements.define('json-attr-override-1', TestElement);


### PR DESCRIPTION
BREAKING CHANGE: `@prop` signature changed
`prop(value?: any, prototypeConfig: OverrideDecoratorConfig = {})`

