### PR TITLE
Feat(esl-utils, esl-image): sanitize html to prevent DOM XSS vulnarabilities

### DIFF
--- a/src/modules/esl-image/core/esl-image-strategies.ts
+++ b/src/modules/esl-image/core/esl-image-strategies.ts
@@ -1,3 +1,4 @@
+import {sanitize} from '../../esl-utils/dom/sanitize';
 import {ESLImage} from './esl-image';
 
 /**
@@ -67,11 +68,7 @@ export const STRATEGIES: ESLImageStrategyMap = {
       request.open('GET', shadowImg.src, true);
       request.onreadystatechange = (): void => {
         if (request.readyState !== 4 || request.status !== 200) return;
-        const tmp = document.createElement('div');
-        tmp.innerHTML = request.responseText;
-        Array.from(tmp.querySelectorAll('script') || [])
-          .forEach((node: Element) => node.remove());
-        img.innerHTML = tmp.innerHTML;
+        img.innerHTML = sanitize(request.responseText, ['svg']);
       };
       request.send();
     },

--- a/src/modules/esl-image/test/esl-image.test.ts
+++ b/src/modules/esl-image/test/esl-image.test.ts
@@ -1,0 +1,67 @@
+import {ESLImage} from '../core';
+import {mockXMLHttpRequest} from './xmlHttpRequest.mock';
+
+describe('ESLImageElement', () => {
+  describe('DOM XSS vulnerabilities in mode="inner-svg"', () => {
+
+    ESLImage.register('esl-image');
+    const el = new ESLImage();
+    el.src = 'http:/localhost/test.svg';
+    el.mode = 'inner-svg';
+    let mock: any;
+
+    beforeAll(() => {
+      mock = mockXMLHttpRequest();
+    });
+    afterAll(() => {
+      mock.cleanUp();
+    });
+
+    afterEach(() => {
+      if (!el.parentElement) return;
+      document.body.removeChild(el);
+    });
+
+    const SVG = '<svg><circle cx="5" cy="5" r="5"></circle></svg>';
+    const DANGER_ATTRS = '<svg onload="alert(document.cookie)"><circle cx="5" cy="5" r="5"></circle></svg>';
+    const DANGER_CONTENT_SCRIPT = '<svg><circle cx="5" cy="5" r="5"></circle><script>alert(\'xss\')</script></svg>';
+    const DANGER_CONTENT_DATA_URI = '<svg><a xlink:href="data:text/html;base64,PHNjcmlwdD5hbGVydCgnWFNTJyk8L3NjcmlwdD4K"><circle cx="5" cy="5" r="5"></circle></a></svg>';
+    const DANGER_CONTENT_LINK_HREF = '<svg><a href="javascript:alert(document.cookie)"><circle cx="5" cy="5" r="5"></circle></a></svg>';
+
+    test('load content from src and put it into innerHTML', () => {
+      mock.setData(SVG);
+      document.body.append(el);
+      expect(el.innerHTML).toBe(SVG);
+    });
+
+    test('SVG with dangerous on event attribute', () => {
+      mock.setData(DANGER_ATTRS);
+      document.body.append(el);
+      expect(el.innerHTML).toBe(SVG);
+    });
+
+    test('SVG with dangerous script in content', () => {
+      mock.setData(DANGER_CONTENT_SCRIPT);
+      document.body.append(el);
+      expect(el.innerHTML).toBe(SVG);
+    });
+
+    test('SVG with the link with malicious attr in content', () => {
+      mock.setData(DANGER_CONTENT_DATA_URI);
+      document.body.append(el);
+      expect(el.innerHTML).toBe('<svg><a><circle cx="5" cy="5" r="5"></circle></a></svg>');
+    });
+
+    test('SVG with the link with malicious href attr in content', () => {
+      mock.setData(DANGER_CONTENT_LINK_HREF);
+      document.body.append(el);
+      expect(el.innerHTML).toBe('<svg><a><circle cx="5" cy="5" r="5"></circle></a></svg>');
+    });
+
+    test('should load only SVG', () => {
+      mock.setData(`<a href="javascript:alert('xss')">Click me!</a>${SVG}`);
+      document.body.append(el);
+      expect(el.innerHTML).toBe(SVG);
+    });
+  });
+});

--- a/src/modules/esl-image/test/xmlHttpRequest.mock.ts
+++ b/src/modules/esl-image/test/xmlHttpRequest.mock.ts
@@ -1,0 +1,70 @@
+interface mockXMLHttpRequestController {
+  open: jest.Mock;
+  onreadystatechange: jest.Mock;
+  cleanUp: () => void;
+  setData: (newData: string, newStatus?: number, newReadyState?: number) => void;
+  send: jest.Mock;
+}
+
+interface mockedXMLHttpRequest {
+  open: jest.Mock;
+  onreadystatechange: jest.Mock;
+  send: jest.Mock;
+  readyState: number;
+  status: number;
+  responseText: string;
+}
+
+export function mockXMLHttpRequest(): mockXMLHttpRequestController  {
+  // mocked properties
+  let readyState = 4;
+  let status = 200;
+  let responseText: string = 'responseText from mocked XMLHttpRequest';
+
+  // mocked functions
+  const open = jest.fn();
+  const onreadystatechange = jest.fn();
+  const send = jest.fn(function send() {
+    this.onreadystatechange();
+  });
+
+  // set data to return on next request
+  function setData(newData: string, newStatus: number = 200, newReadyState: number = 4): void {
+    responseText = newData;
+    status = newStatus;
+    readyState = newReadyState;
+  }
+
+  // clean up mocked implementation
+  function cleanUp(): void {
+    if (window.XMLHttpRequest) {
+      // @ts-ignore
+      delete window.XMLHttpRequest;
+    }
+  }
+
+  // mock constructor that will replace window XMLHttpRequest
+  function mockConstructor(): mockedXMLHttpRequest {
+    return {
+      readyState,
+      status,
+      responseText,
+      open,
+      onreadystatechange,
+      send
+    };
+  }
+
+  // override/define XMLHttpRequest
+  // @ts-ignore
+  window.XMLHttpRequest = mockConstructor;
+
+  // returning necessary methods for further testing and functionality
+  return {
+    open,
+    onreadystatechange,
+    cleanUp,
+    setData,
+    send
+  };
+}

--- a/src/modules/esl-utils/all.ts
+++ b/src/modules/esl-utils/all.ts
@@ -38,6 +38,7 @@ export * from './dom/focus';
 export * from './dom/keys';
 export * from './dom/ready';
 export * from './dom/rtl';
+export * from './dom/sanitize';
 export * from './dom/script';
 export * from './dom/scroll';
 export * from './dom/traversing';

--- a/src/modules/esl-utils/dom/sanitize.ts
+++ b/src/modules/esl-utils/dom/sanitize.ts
@@ -1,0 +1,58 @@
+/** checks if the attribute is dangerous */
+const isDangerousAttribute = (name: string, value: string): boolean => {
+  const val = value.replace(/\s+/g, '').toLowerCase();
+  if (['src', 'data', 'href', 'xlink:href'].includes(name)
+    && (val.includes('javascript:') || val.includes('data:text/html'))) return true;
+  if (name.indexOf('on') === 0) return true;
+  return false;
+};
+
+/** loops through each attribute, if it's dangerous, remove it */
+const removeDangerousAttributes = (el: Element): void => {
+  Array.from(el.attributes).forEach(({name, value}) => {
+    if (isDangerousAttribute(name, value)) {
+      el.removeAttribute(name);
+    }
+  });
+};
+
+/** removes malicious attributes from element and its children */
+const sanitizeElAttributes = (body: Element): void => {
+  Array.from(body.children).forEach((el) => {
+    removeDangerousAttributes(el);
+    sanitizeElAttributes(el);
+  });
+};
+
+/** removes script elements inside element */
+const removeScripts = (body: Element): void => {
+  const scripts = body.querySelectorAll('script');
+  Array.from(scripts).forEach((script) => script.remove());
+};
+
+const filterElements = (body: Element, allowedTopLevelTags: string[]): void => {
+  if (!allowedTopLevelTags.length) return;
+  Array.from(body.childNodes).forEach((el: Element) => {
+    if (!allowedTopLevelTags.includes(el.tagName)) body.removeChild(el);
+  });
+};
+
+/**
+ * Sanitizes html string from malicious attributes, values, and scripts
+ * Can also filter elements at the top nesting level by tag names.
+ * @param html - html string to sanitize
+ * @param allowedTopLevelTags - array of allowed tag names
+ */
+export function sanitize(html: string, allowedTopLevelTags: string[] = []): string {
+  // converts the string to an HTML document
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, 'text/html');
+  const body = doc.body || document.createElement('body');
+  // sanitizes html
+  removeScripts(body);
+  sanitizeElAttributes(body);
+  // filter allowed tags
+  filterElements(body, allowedTopLevelTags);
+
+  return body.innerHTML;
+}

--- a/src/modules/esl-utils/dom/test/sanitize.test.ts
+++ b/src/modules/esl-utils/dom/test/sanitize.test.ts
@@ -1,0 +1,58 @@
+import {sanitize} from '../sanitize';
+
+describe('sanitize', () => {
+  test('should return the original markup', () => {
+    const markup = '<div><p>Text</p></div>';
+    const html = sanitize(markup);
+    expect(html).toBe(markup);
+  });
+
+  test('should clean dangerous script', () => {
+    const markup = '<div><p>Text</p></div>';
+    const html = sanitize(`<script>alert(document.cookie)</script>${markup}`);
+    expect(html).toBe(markup);
+  });
+
+  test('should clean dangerous script inside another elements', () => {
+    const html = sanitize('<div><div><script>alert(document.cookie)</script></div></div>');
+    expect(html).toBe('<div><div></div></div>');
+  });
+
+  test('should clean dangerous on event attributes', () => {
+    const markup = '<div><p>Text</p></div>';
+    const html = sanitize(`${markup}<img src="x" onerror="alert(document.cookie)">`);
+    expect(html).toBe(`${markup}<img src="x">`);
+  });
+
+  test('should clean dangerous href attribute with javascript content', () => {
+    const markup = '<div><p>Text</p></div>';
+    const html = sanitize(`<a href="javascript:alert(document.cookie)">${markup}</a>`);
+    expect(html).toBe(`<a>${markup}</a>`);
+  });
+
+  test('should clean dangerous src attribute with data-uri text/html content', () => {
+    const html = sanitize('<iframe src="data:text/html;base64,PHNjcmlwdD5hbGVydCgnWFNTJyk8L3NjcmlwdD4K"></iframe>');
+    expect(html).toBe('<iframe></iframe>');
+  });
+
+  test('should clean dangerous data attribute with data-uri text/html content', () => {
+    const html = sanitize('<object data="data:text/html;base64,PHNjcmlwdD5hbGVydCgnWFNTJyk8L3NjcmlwdD4K"></object>');
+    expect(html).toBe('<object></object>');
+  });
+
+  test('should clean dangerous xlink:href attributes with data-uri text/html content', () => {
+    const markup = '<rect width="100" height="100"></rect>';
+    const html = sanitize(`<a xlink:href="data:text/html;base64,PHNjcmlwdD5hbGVydCgnWFNTJyk8L3NjcmlwdD4K">${markup}</a>`);
+    expect(html).toBe(`<a>${markup}</a>`);
+  });
+
+  test('should filter first level elements by tags', () => {
+    const html = sanitize('<h1>Title</h1><h2>Header</h2><div><p>Text</p></div>', ['H1']);
+    expect(html).toBe('<h1>Title</h1>');
+  });
+
+  test('should filter elements only at first level', () => {
+    const html = sanitize('<div><p>Text</p></div><p>Another text</p>', ['P']);
+    expect(html).toBe('<p>Another text</p>');
+  });
+});


### PR DESCRIPTION
In scope of this PR:
 - create esl-utils dom helper to sanitize html
 - modify esl-image to prevent DOM XSS vulnerabilities

Closes: #1058