### PR TITLE
chore: tests speed-up

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,11 @@ module.exports = {
     './src/modules/esl-utils/test/deviceDetector.mock.ts',
     './src/modules/esl-utils/test/matchMedia.mock.ts'
   ],
+  globals: {
+    'ts-jest': {
+      isolatedModules: true
+    }
+  },
   collectCoverageFrom: [
     'src/modules/**/*.ts',
     // test dir


### PR DESCRIPTION
The small Jest config improvements speed up running tests two times.

Before:
![sshot_2022-07-04-19-21-50](https://user-images.githubusercontent.com/564184/177196766-f24de2b2-5f97-44c2-978c-789c398b9693.png)
After:
![sshot_2022-07-04-19-22-11](https://user-images.githubusercontent.com/564184/177196779-87db5a11-e465-4cda-abf8-1bfaed8d1dc7.png)
 