### PR TITLE
test(esl-utils): scroll utils code improvements and scroll utils test coverage

### DIFF
--- a/src/modules/esl-utils/dom/scroll/parent.ts
+++ b/src/modules/esl-utils/dom/scroll/parent.ts
@@ -9,7 +9,7 @@ export function getListScrollParents(element: Element, list: Element[] = []): El
   const scrollParent = getScrollParent(element);
   const isBody = scrollParent === element.ownerDocument?.body;
   const target = isBody
-    ? isScrollParent(scrollParent) ? scrollParent : []
+    ? isScrollable(scrollParent) ? scrollParent : []
     : scrollParent;
 
   const updatedList = list.concat(target);
@@ -27,7 +27,7 @@ export function getScrollParent(node: Element): Element {
     return node.ownerDocument?.body as Element;
   }
 
-  if (node instanceof HTMLElement && isScrollParent(node as Element)) {
+  if (node instanceof HTMLElement && isScrollable(node as Element)) {
     return node as Element;
   }
 
@@ -38,7 +38,7 @@ export function getScrollParent(node: Element): Element {
  * Check that element is scroll parent.
  * @param element - element for checking
  * */
-export function isScrollParent(element: Element): boolean {
+export function isScrollable(element: Element): boolean {
   // Firefox wants us to check `-x` and `-y` variations as well
   const {overflow, overflowX, overflowY} = getComputedStyle(element);
   return /auto|scroll|overlay|hidden/.test(overflow + overflowY + overflowX);

--- a/src/modules/esl-utils/dom/scroll/test/parent.test.ts
+++ b/src/modules/esl-utils/dom/scroll/test/parent.test.ts
@@ -1,0 +1,111 @@
+import {isScrollable, getScrollParent, getListScrollParents} from '../parent';
+
+const $html = document.documentElement;
+const $body = document.body;
+
+describe('Function isScrollParent', () => {
+  const element = document.createElement('div');
+
+  test('element isn`t scrollable', () => {
+    expect(isScrollable(element)).toBeFalsy();
+
+    element.style.overflow = 'inherit';
+    expect(isScrollable(element)).toBeFalsy();
+  });
+
+  test('element is scrollable', () => {
+    element.style.overflow = 'auto';
+    expect(isScrollable(element)).toBeTruthy();
+
+    element.style.overflow = 'scroll';
+    expect(isScrollable(element)).toBeTruthy();
+
+    element.style.overflow = 'overlay';
+    expect(isScrollable(element)).toBeTruthy();
+
+    element.style.overflow = 'hidden';
+    expect(isScrollable(element)).toBeTruthy();
+  });
+});
+
+describe('Function getScrollParent', () => {
+  const element = document.createElement('div');
+
+  describe('Element doesn`t have scrollable parent(s)', () => {
+    beforeAll(() => element.style.overflow = '');
+
+    test('scrollable parent not found for specified element', () => {
+      expect(getScrollParent(element)).toEqual($body);
+    });
+
+    test('scrollable parent not found for body element', () => {
+      expect(getScrollParent($body)).toEqual($body);
+    });
+
+    test('scrollable parent not found for html element', () => {
+      expect(getScrollParent($html)).toEqual($body);
+    });
+  });
+
+  describe('Element does have scrollable parent(s)', () => {
+    const firstLevelChild = document.createElement('div');
+    const secondLevelChild = document.createElement('div');
+    const thirdLevelChild = document.createElement('div');
+
+    secondLevelChild.appendChild(thirdLevelChild);
+    element.appendChild(firstLevelChild);
+    firstLevelChild.appendChild(secondLevelChild);
+
+    beforeAll(() => element.style.overflow = 'auto');
+
+    test('specified element is scrollable', () => {
+      expect(getScrollParent(element)).toEqual(element);
+    });
+
+    test('scrollable parent on 1st level of element tree', () => {
+      expect(getScrollParent(firstLevelChild)).toEqual(element);
+    });
+
+    test('scrollable parent on 2nd level of element tree', () => {
+      expect(getScrollParent(secondLevelChild)).toEqual(element);
+    });
+
+    test('scrollable parent on 3rd level of element tree', () => {
+      expect(getScrollParent(thirdLevelChild)).toEqual(element);
+    });
+  });
+});
+
+describe('Function getListScrollParents', () => {
+  const element = document.createElement('div');
+
+  test('scroll parent(s) not found for element', () => {
+    expect(getListScrollParents(element)).toEqual([]);
+  });
+
+  test('scroll parent is element itself', () => {
+    element.style.overflow = 'auto';
+    expect(getListScrollParents(element)).toEqual([element]);
+  });
+
+  test('scroll parent is body element', () => {
+    element.style.overflow = '';
+    $body.style.overflow = 'auto';
+    expect(getListScrollParents(element)).toEqual([$body]);
+  });
+
+  test('multiple scrollable parents', () => {
+    const firstLevelChild = document.createElement('div');
+    const secondLevelChild = document.createElement('div');
+    const thirdLevelChild = document.createElement('div');
+
+    firstLevelChild.style.overflow = 'auto';
+    thirdLevelChild.style.overflow = 'auto';
+
+    secondLevelChild.appendChild(thirdLevelChild);
+    element.appendChild(firstLevelChild);
+    firstLevelChild.appendChild(secondLevelChild);
+
+    expect(getListScrollParents(thirdLevelChild)).toEqual([thirdLevelChild, firstLevelChild, $body]);
+  });
+});

--- a/src/modules/esl-utils/dom/scroll/test/parent.test.ts
+++ b/src/modules/esl-utils/dom/scroll/test/parent.test.ts
@@ -3,7 +3,7 @@ import {isScrollable, getScrollParent, getListScrollParents} from '../parent';
 const $html = document.documentElement;
 const $body = document.body;
 
-describe('Function isScrollParent', () => {
+describe('Function isScrollable', () => {
   const target = document.createElement('div');
 
   describe('Element isn`t scrollable', () => {

--- a/src/modules/esl-utils/dom/scroll/test/parent.test.ts
+++ b/src/modules/esl-utils/dom/scroll/test/parent.test.ts
@@ -4,45 +4,57 @@ const $html = document.documentElement;
 const $body = document.body;
 
 describe('Function isScrollParent', () => {
-  const element = document.createElement('div');
+  const target = document.createElement('div');
 
-  test('element isn`t scrollable', () => {
-    expect(isScrollable(element)).toBeFalsy();
+  describe('Element isn`t scrollable', () => {
+    test('element shouldn`t be scrollable without overflow property', () => {
+      expect(isScrollable(target)).toBeFalsy();
+    });
 
-    element.style.overflow = 'inherit';
-    expect(isScrollable(element)).toBeFalsy();
+    test('element shouldn`t be scrollable with overflow property value "inherit"', () => {
+      target.style.overflow = 'inherit';
+      expect(isScrollable(target)).toBeFalsy();
+    });
   });
 
-  test('element is scrollable', () => {
-    element.style.overflow = 'auto';
-    expect(isScrollable(element)).toBeTruthy();
+  describe('Element is scrollable', () => {
+    test('element should be scrollable with overflow property value "auto"', () => {
+      target.style.overflow = 'auto';
+      expect(isScrollable(target)).toBeTruthy();
+    });
 
-    element.style.overflow = 'scroll';
-    expect(isScrollable(element)).toBeTruthy();
+    test('element should be scrollable with overflow property value "scroll"', () => {
+      target.style.overflow = 'scroll';
+      expect(isScrollable(target)).toBeTruthy();
+    });
 
-    element.style.overflow = 'overlay';
-    expect(isScrollable(element)).toBeTruthy();
+    test('element should be scrollable with overflow property value "overlay"', () => {
+      target.style.overflow = 'overlay';
+      expect(isScrollable(target)).toBeTruthy();
+    });
 
-    element.style.overflow = 'hidden';
-    expect(isScrollable(element)).toBeTruthy();
+    test('element should be scrollable with overflow property value "hidden"', () => {
+      target.style.overflow = 'hidden';
+      expect(isScrollable(target)).toBeTruthy();
+    });
   });
 });
 
 describe('Function getScrollParent', () => {
-  const element = document.createElement('div');
+  const target = document.createElement('div');
 
   describe('Element doesn`t have scrollable parent(s)', () => {
-    beforeAll(() => element.style.overflow = '');
+    beforeAll(() => target.style.overflow = '');
 
-    test('scrollable parent not found for specified element', () => {
-      expect(getScrollParent(element)).toEqual($body);
+    test('scroll parent shouldn`t be found for specified element', () => {
+      expect(getScrollParent(target)).toEqual($body);
     });
 
-    test('scrollable parent not found for body element', () => {
+    test('scroll parent shouldn`t be found for target`s parent element', () => {
       expect(getScrollParent($body)).toEqual($body);
     });
 
-    test('scrollable parent not found for html element', () => {
+    test('scroll parent shouldn`t be found for html element', () => {
       expect(getScrollParent($html)).toEqual($body);
     });
   });
@@ -53,48 +65,48 @@ describe('Function getScrollParent', () => {
     const thirdLevelChild = document.createElement('div');
 
     secondLevelChild.appendChild(thirdLevelChild);
-    element.appendChild(firstLevelChild);
+    target.appendChild(firstLevelChild);
     firstLevelChild.appendChild(secondLevelChild);
 
-    beforeAll(() => element.style.overflow = 'auto');
+    beforeAll(() => target.style.overflow = 'auto');
 
-    test('specified element is scrollable', () => {
-      expect(getScrollParent(element)).toEqual(element);
+    test('target element should be scrollable', () => {
+      expect(getScrollParent(target)).toEqual(target);
     });
 
-    test('scrollable parent on 1st level of element tree', () => {
-      expect(getScrollParent(firstLevelChild)).toEqual(element);
+    test('parent should be scrollable on 1st level of element tree', () => {
+      expect(getScrollParent(firstLevelChild)).toEqual(target);
     });
 
-    test('scrollable parent on 2nd level of element tree', () => {
-      expect(getScrollParent(secondLevelChild)).toEqual(element);
+    test('parent should be scrollable on 2nd level of element tree', () => {
+      expect(getScrollParent(secondLevelChild)).toEqual(target);
     });
 
-    test('scrollable parent on 3rd level of element tree', () => {
-      expect(getScrollParent(thirdLevelChild)).toEqual(element);
+    test('parent should be scrollable on 3rd level of element tree', () => {
+      expect(getScrollParent(thirdLevelChild)).toEqual(target);
     });
   });
 });
 
 describe('Function getListScrollParents', () => {
-  const element = document.createElement('div');
+  const taget = document.createElement('div');
 
-  test('scroll parent(s) not found for element', () => {
-    expect(getListScrollParents(element)).toEqual([]);
+  test('target`s scroll parent(s) should not be found for element', () => {
+    expect(getListScrollParents(taget)).toEqual([]);
   });
 
-  test('scroll parent is element itself', () => {
-    element.style.overflow = 'auto';
-    expect(getListScrollParents(element)).toEqual([element]);
+  test('target`s scroll parent should be target element itself', () => {
+    taget.style.overflow = 'auto';
+    expect(getListScrollParents(taget)).toEqual([taget]);
   });
 
-  test('scroll parent is body element', () => {
-    element.style.overflow = '';
+  test('target`s scroll parent should be target`s parent element', () => {
+    taget.style.overflow = '';
     $body.style.overflow = 'auto';
-    expect(getListScrollParents(element)).toEqual([$body]);
+    expect(getListScrollParents(taget)).toEqual([$body]);
   });
 
-  test('multiple scrollable parents', () => {
+  test('target should have multiple scrollable parents', () => {
     const firstLevelChild = document.createElement('div');
     const secondLevelChild = document.createElement('div');
     const thirdLevelChild = document.createElement('div');
@@ -103,7 +115,7 @@ describe('Function getListScrollParents', () => {
     thirdLevelChild.style.overflow = 'auto';
 
     secondLevelChild.appendChild(thirdLevelChild);
-    element.appendChild(firstLevelChild);
+    taget.appendChild(firstLevelChild);
     firstLevelChild.appendChild(secondLevelChild);
 
     expect(getListScrollParents(thirdLevelChild)).toEqual([thirdLevelChild, firstLevelChild, $body]);

--- a/src/modules/esl-utils/dom/scroll/test/parent.test.ts
+++ b/src/modules/esl-utils/dom/scroll/test/parent.test.ts
@@ -8,34 +8,34 @@ describe('Function isScrollable', () => {
 
   describe('Element isn`t scrollable', () => {
     test('element shouldn`t be scrollable without overflow property', () => {
-      expect(isScrollable(target)).toBeFalsy();
+      expect(isScrollable(target)).toBe(false);
     });
 
     test('element shouldn`t be scrollable with overflow property value "inherit"', () => {
       target.style.overflow = 'inherit';
-      expect(isScrollable(target)).toBeFalsy();
+      expect(isScrollable(target)).toBe(false);
     });
   });
 
   describe('Element is scrollable', () => {
     test('element should be scrollable with overflow property value "auto"', () => {
       target.style.overflow = 'auto';
-      expect(isScrollable(target)).toBeTruthy();
+      expect(isScrollable(target)).toBe(true);
     });
 
     test('element should be scrollable with overflow property value "scroll"', () => {
       target.style.overflow = 'scroll';
-      expect(isScrollable(target)).toBeTruthy();
+      expect(isScrollable(target)).toBe(true);
     });
 
     test('element should be scrollable with overflow property value "overlay"', () => {
       target.style.overflow = 'overlay';
-      expect(isScrollable(target)).toBeTruthy();
+      expect(isScrollable(target)).toBe(true);
     });
 
     test('element should be scrollable with overflow property value "hidden"', () => {
       target.style.overflow = 'hidden';
-      expect(isScrollable(target)).toBeTruthy();
+      expect(isScrollable(target)).toBe(true);
     });
   });
 });
@@ -89,21 +89,21 @@ describe('Function getScrollParent', () => {
 });
 
 describe('Function getListScrollParents', () => {
-  const taget = document.createElement('div');
+  const target = document.createElement('div');
 
   test('target`s scroll parent(s) should not be found for element', () => {
-    expect(getListScrollParents(taget)).toEqual([]);
+    expect(getListScrollParents(target)).toEqual([]);
   });
 
   test('target`s scroll parent should be target element itself', () => {
-    taget.style.overflow = 'auto';
-    expect(getListScrollParents(taget)).toEqual([taget]);
+    target.style.overflow = 'auto';
+    expect(getListScrollParents(target)).toEqual([target]);
   });
 
   test('target`s scroll parent should be target`s parent element', () => {
-    taget.style.overflow = '';
+    target.style.overflow = '';
     $body.style.overflow = 'auto';
-    expect(getListScrollParents(taget)).toEqual([$body]);
+    expect(getListScrollParents(target)).toEqual([$body]);
   });
 
   test('target should have multiple scrollable parents', () => {
@@ -115,7 +115,7 @@ describe('Function getListScrollParents', () => {
     thirdLevelChild.style.overflow = 'auto';
 
     secondLevelChild.appendChild(thirdLevelChild);
-    taget.appendChild(firstLevelChild);
+    target.appendChild(firstLevelChild);
     firstLevelChild.appendChild(secondLevelChild);
 
     expect(getListScrollParents(thirdLevelChild)).toEqual([thirdLevelChild, firstLevelChild, $body]);

--- a/src/modules/esl-utils/dom/scroll/test/utils.test.ts
+++ b/src/modules/esl-utils/dom/scroll/test/utils.test.ts
@@ -18,26 +18,26 @@ const mockElWidth = (el: Element) => {
 describe('Function hasVerticalScroll', () => {
   test('should be vertical scroll on default element', () => {
     mockElHeight($html);
-    expect(hasVerticalScroll()).toBeTruthy();
+    expect(hasVerticalScroll()).toBe(true);
   });
 
   test('should be vertical scroll on target element', () => {
     const target = document.createElement('div');
     mockElHeight(target);
-    expect(hasVerticalScroll(target)).toBeTruthy();
+    expect(hasVerticalScroll(target)).toBe(true);
   });
 });
 
 describe('Function hasHorizontalScroll', () => {
   test('should be horizontal scroll on default element', () => {
     mockElWidth($html);
-    expect(hasHorizontalScroll()).toBeTruthy();
+    expect(hasHorizontalScroll()).toBe(true);
   });
 
   test('should be horizontal scroll on target element', () => {
     const target = document.createElement('div');
     mockElWidth(target);
-    expect(hasHorizontalScroll(target)).toBeTruthy();
+    expect(hasHorizontalScroll(target)).toBe(true);
   });
 });
 
@@ -46,14 +46,14 @@ describe('Function isScrollLocked', () => {
   target.style.overflow = 'auto';
   describe('Locked Scroll', () => {
     beforeAll(() => lockScroll(target));
-    test('lock attribute should be set', () => expect(target.hasAttribute('esl-scroll-lock')).toBeTruthy());
-    test('target should be locked', () => expect(isScrollLocked(target)).toBeTruthy());
+    test('lock attribute should be set', () => expect(target.hasAttribute('esl-scroll-lock')).toBe(true));
+    test('target should be locked', () => expect(isScrollLocked(target)).toBe(true));
   });
 
   describe('Unlocked Scroll', () => {
     beforeAll(() => unlockScroll(target));
-    test('lock attribute should be removed', () => expect(target.hasAttribute('esl-scroll-lock')).toBeFalsy());
-    test('target should be locked', () => expect(isScrollLocked(target)).toBeFalsy());
+    test('lock attribute should be removed', () => expect(target.hasAttribute('esl-scroll-lock')).toBe(false));
+    test('target should be locked', () => expect(isScrollLocked(target)).toBe(false));
   });
 });
 
@@ -64,18 +64,18 @@ describe('Function lockScroll', () => {
 
   test('target`s parent should be locked', () => {
     lockScroll(target);
-    expect(isScrollLocked($body)).toBeTruthy();
+    expect(isScrollLocked($body)).toBe(true);
   });
 
   test('target should be locked', () => {
     target.style.overflow = 'auto';
     lockScroll(target);
-    expect(isScrollLocked(target)).toBeTruthy();
+    expect(isScrollLocked(target)).toBe(true);
   });
 
   test('default element should be locked', () => {
     lockScroll();
-    expect(isScrollLocked($html)).toBeTruthy();
+    expect(isScrollLocked($html)).toBe(true);
   });
 
   describe('Scroll lock with recursive option', () => {
@@ -84,42 +84,40 @@ describe('Function lockScroll', () => {
     jest.spyOn(target, 'parentElement', 'get').mockImplementation(() => $body);
 
     lockScroll(target, {recursive: true});
-    test('target should be locked', () => expect(isScrollLocked(target)).toBeTruthy());
-    test('target`s parent should be locked', () => expect(isScrollLocked($body)).toBeTruthy());
+    test('target should be locked', () => expect(isScrollLocked(target)).toBe(true));
+    test('target`s parent should be locked', () => expect(isScrollLocked($body)).toBe(true));
   });
 
   describe('Lock with initiator', () => {
     describe('Lock with initiator should be successful', () => {
-      beforeAll(() => {
-        jest.spyOn(target, 'setAttribute');
-        lockScroll(target, {initiator: 'init'});
+      test('target should be unlocked initially', () => {
+        unlockScroll(target);
+        expect(isScrollLocked(target)).toBe(false);
       });
 
-      test('setAttribute should have been called', () => expect(target.setAttribute).toHaveBeenCalled());
-      test('target should be locked', () => expect(isScrollLocked(target)).toBeTruthy());
+      test('target should be locked', () => {
+        lockScroll(target, {initiator: 'init'});
+        expect(isScrollLocked(target)).toBe(true);
+      });
     });
 
     describe('Lock with duplicate initiator', () => {
-      beforeAll(() => {
-        jest.spyOn(target, 'setAttribute');
-        lockScroll(target, {initiator: 'init'});
-      });
+      test('target should be locked initially', () => expect(isScrollLocked(target)).toBe(true));
 
-      test('setAttribute shouldn`t have been called again', () => expect(target.setAttribute).toHaveBeenCalledTimes(0));
-      test('target should be locked', () => expect(isScrollLocked(target)).toBeTruthy());
+      test('target should be locked', () => {
+        lockScroll(target, {initiator: 'init'});
+        expect(isScrollLocked(target)).toBe(true);});
     });
 
     describe('Lock with initiator recursively', () => {
       beforeAll(() => {
         unlockScroll(target, {initiator: 'init'});
-        jest.spyOn($body, 'setAttribute');
         jest.spyOn(target, 'parentElement', 'get').mockImplementation(() => $body);
         lockScroll(target, {initiator: 'init', recursive: true});
       });
 
-      test('setAttribute should have been called on target`s parent', () => expect($body.setAttribute).toHaveBeenCalledTimes(1));
-      test('target should be locked', () => expect(isScrollLocked(target)).toBeTruthy());
-      test('target`s parent should be locked', () => expect(isScrollLocked($body)).toBeTruthy());
+      test('target should be locked', () => expect(isScrollLocked(target)).toBe(true));
+      test('target`s parent should be locked', () => expect(isScrollLocked($body)).toBe(true));
     });
   });
 
@@ -156,12 +154,12 @@ describe('Function unlockScroll', () => {
     target.style.overflow = 'auto';
     test('target should be initially locked', () => {
       lockScroll(target);
-      expect(isScrollLocked(target)).toBeTruthy();
+      expect(isScrollLocked(target)).toBe(true);
     });
 
     test('target should be unlocked', () => {
       unlockScroll(target);
-      expect(isScrollLocked(target)).toBeFalsy();
+      expect(isScrollLocked(target)).toBe(false);
     });
   });
 
@@ -169,24 +167,24 @@ describe('Function unlockScroll', () => {
     const first = document.createElement('div');
     test('parent should be initially locked', () => {
       lockScroll($body);
-      expect(isScrollLocked($body)).toBeTruthy();
+      expect(isScrollLocked($body)).toBe(true);
     });
 
     test('target should be unlocked', () => {
       unlockScroll(first);
-      expect(isScrollLocked($body)).toBeFalsy();
+      expect(isScrollLocked($body)).toBe(false);
     });
   });
 
   describe('Unlock scroll on default element', () => {
     test('default element should be initially locked', () => {
       lockScroll();
-      expect(isScrollLocked($html)).toBeTruthy();
+      expect(isScrollLocked($html)).toBe(true);
     });
 
     test('default element should be unlocked', () => {
       unlockScroll();
-      expect(isScrollLocked($html)).toBeFalsy();
+      expect(isScrollLocked($html)).toBe(false);
     });
   });
 
@@ -201,9 +199,9 @@ describe('Function unlockScroll', () => {
 
     unlockScroll(target, {recursive: true});
 
-    test('target element should be unlocked', () => expect(isScrollLocked(target)).toBeFalsy());
-    test('taget`s parent element should be unlocked', () => expect(isScrollLocked($body)).toBeFalsy());
-    test('default element should be unlocked', () => expect(isScrollLocked($html)).toBeFalsy());
+    test('target element should be unlocked', () => expect(isScrollLocked(target)).toBe(false));
+    test('target`s parent element should be unlocked', () => expect(isScrollLocked($body)).toBe(false));
+    test('default element should be unlocked', () => expect(isScrollLocked($html)).toBe(false));
   });
 
   describe('Unlock scroll with initiator', () => {
@@ -211,21 +209,17 @@ describe('Function unlockScroll', () => {
     target.style.overflow = 'auto';
 
     test('target element should unlock with initiator', () => {
-      jest.spyOn(target, 'removeAttribute');
       lockScroll(target, {initiator: 'init'});
 
       unlockScroll(target, {initiator: 'init'});
-      expect(target.removeAttribute).toHaveBeenCalled();
-      expect(isScrollLocked(target)).toBeFalsy();
+      expect(isScrollLocked(target)).toBe(false);
     });
 
     test('target element shouldn`t unlock with wrong initiator', () => {
-      jest.spyOn(target, 'removeAttribute');
       lockScroll(target, {initiator: 'init'});
 
       unlockScroll(target, {initiator: 'init2'});
-      expect(target.removeAttribute).toHaveBeenCalledTimes(0);
-      expect(isScrollLocked(target)).toBeTruthy();
+      expect(isScrollLocked(target)).toBe(true);
     });
   });
 
@@ -235,24 +229,24 @@ describe('Function unlockScroll', () => {
     const second = document.createElement('div');
     target.style.overflow = 'auto';
 
-    test('target should initially be unlocked', () => expect(isScrollLocked(target)).toBeFalsy());
+    test('target should initially be unlocked', () => expect(isScrollLocked(target)).toBe(false));
 
     test('first initiator should lock the target', () => {
       lockScroll(target, {initiator: first});
-      expect(isScrollLocked(target)).toBeTruthy();
+      expect(isScrollLocked(target)).toBe(true);
     });
 
     test('second initiator should lock the target', () => {
       lockScroll(target, {initiator: second});
-      expect(isScrollLocked(target)).toBeTruthy();
+      expect(isScrollLocked(target)).toBe(true);
     });
 
     test('first initiator should attempt to unlock the target, but the target still locked by the second one', () => {
       unlockScroll(target, {initiator: first});
-      expect(isScrollLocked(target)).toBeTruthy();});
+      expect(isScrollLocked(target)).toBe(true);});
 
     test('second initiator should completely unlock the target', () => {
       unlockScroll(target, {initiator: second});
-      expect(isScrollLocked(target)).toBeFalsy();});
+      expect(isScrollLocked(target)).toBe(false);});
   });
 });

--- a/src/modules/esl-utils/dom/scroll/test/utils.test.ts
+++ b/src/modules/esl-utils/dom/scroll/test/utils.test.ts
@@ -1,0 +1,191 @@
+import {hasHorizontalScroll, hasVerticalScroll, isScrollLocked, lockScroll, unlockScroll} from '../utils';
+
+const $html = document.documentElement;
+const $body = document.body;
+
+afterEach(() => jest.clearAllMocks());
+
+describe('Function hasVerticalScroll', () => {
+  test('Vertical scroll on default element', () => {
+    jest.spyOn($html, 'scrollHeight', 'get').mockImplementation(() => 100);
+    jest.spyOn($html, 'clientHeight', 'get').mockImplementation(() => 99);
+    expect(hasVerticalScroll()).toBeTruthy();
+  });
+
+  test('Vertical scroll on element', () => {
+    const element = document.createElement('div');
+    jest.spyOn(element, 'scrollHeight', 'get').mockImplementation(() => 100);
+    jest.spyOn(element, 'clientHeight', 'get').mockImplementation(() => 99);
+    expect(hasVerticalScroll(element)).toBeTruthy();
+  });
+});
+
+describe('Function hasHorizontalScroll', () => {
+  test('Horizontal scroll on default element', () => {
+    jest.spyOn($html, 'scrollWidth', 'get').mockImplementation(() => 100);
+    jest.spyOn($html, 'clientWidth', 'get').mockImplementation(() => 99);
+    expect(hasHorizontalScroll()).toBeTruthy();
+  });
+
+  test('Horizontal scroll on element', () => {
+    const element = document.createElement('div');
+    jest.spyOn(element, 'scrollWidth', 'get').mockImplementation(() => 100);
+    jest.spyOn(element, 'clientWidth', 'get').mockImplementation(() => 99);
+    expect(hasHorizontalScroll(element)).toBeTruthy();
+  });
+});
+
+describe('Function isScrollLocked', () => {
+  test('locked Scroll', () => {
+    lockScroll($body);
+    expect($body.hasAttribute('esl-scroll-lock')).toBeTruthy();
+    expect(isScrollLocked($body)).toBeTruthy();
+  });
+
+  test('unlocked Scroll', () => {
+    unlockScroll($body);
+    expect($body.hasAttribute('esl-scroll-lock')).toBeFalsy();
+    expect(isScrollLocked($body)).toBeFalsy();
+  });
+});
+
+describe('Function lockScroll', () => {
+  const element = document.createElement('div');
+
+  test('lock on element`s parent', () => {
+    $body.style.overflow = 'auto';
+    lockScroll(element);
+    expect(isScrollLocked($body)).toBeTruthy();
+  });
+
+  test('lock on element', () => {
+    element.style.overflow = 'auto';
+    lockScroll(element);
+    expect(isScrollLocked(element)).toBeTruthy();
+  });
+
+  test('lock on default element', () => {
+    $html.style.overflow = 'auto';
+    lockScroll();
+    expect(isScrollLocked($html)).toBeTruthy();
+  });
+
+
+  test('lock with recursive option', () => {
+    unlockScroll(element);
+    element.style.overflow = 'auto';
+    jest.spyOn(element, 'parentElement', 'get').mockImplementation(() => $body);
+    lockScroll(element, {recursive: true});
+    expect(isScrollLocked(element)).toBeTruthy();
+    expect(isScrollLocked($body)).toBeTruthy();
+  });
+
+  describe('Lock with initiator', () => {
+    test('lock with initiator', () => {
+      jest.spyOn(element, 'setAttribute');
+      lockScroll(element, {initiator: 'init'});
+      expect(element.setAttribute).toHaveBeenCalled();
+      expect(isScrollLocked(element)).toBeTruthy();
+    });
+
+    test('shoudn`t be locked second time', () => {
+      jest.spyOn(element, 'setAttribute');
+      lockScroll(element, {initiator: 'init'});
+      expect(element.setAttribute).toHaveBeenCalledTimes(0);
+    });
+
+    test('each element should have it`s own initiator', () => {
+      unlockScroll(element, {initiator: 'init'});
+      jest.spyOn($body, 'setAttribute');
+      jest.spyOn(element, 'parentElement', 'get').mockImplementation(() => $body);
+      lockScroll(element, {initiator: 'init', recursive: true});
+      expect($body.setAttribute).toHaveBeenCalledTimes(1);
+      expect(isScrollLocked(element)).toBeTruthy();
+      expect(isScrollLocked($body)).toBeTruthy();
+    });
+  });
+
+  describe('Lock scroll with strategy', () => {
+    $html.style.overflow = 'auto';
+    test('no strategy', () => {
+      lockScroll($html, {strategy: 'none'});
+      expect($html.getAttribute('esl-scroll-lock')).toBe('none');
+
+      lockScroll($html);
+      expect($html.getAttribute('esl-scroll-lock')).toBe('');
+    });
+
+    test('native strategy', () => {
+      lockScroll($html, {strategy: 'native'});
+      expect($html.getAttribute('esl-scroll-lock')).toBe('native');
+    });
+
+    test('native strategy', () => {
+      lockScroll($html, {strategy: 'pseudo'});
+      expect($html.getAttribute('esl-scroll-lock')).toBe('pseudo');
+    });
+  });
+});
+
+describe('Function unlockScroll', () => {
+  const scrollableEl = document.createElement('div');
+
+  $html.style.overflow = 'auto';
+  $body.style.overflow = 'auto';
+  scrollableEl.style.overflow = 'auto';
+
+  test('lock on element', () => {
+    $body.style.overflow = 'auto';
+    lockScroll(scrollableEl);
+    lockScroll($body);
+
+    unlockScroll(scrollableEl);
+    expect(isScrollLocked(scrollableEl)).toBeFalsy();
+  });
+
+  test('unlock element`s first parent', () => {
+    const element = document.createElement('div');
+    lockScroll($body);
+
+    unlockScroll(element);
+    expect(isScrollLocked($body)).toBeFalsy();
+  });
+
+  test('unlock default element', () => {
+    unlockScroll();
+    expect(isScrollLocked($html)).toBeFalsy();
+  });
+
+  test('unlock recursively', () => {
+    lockScroll(scrollableEl);
+    lockScroll($body);
+    lockScroll($html);
+    jest.spyOn(scrollableEl, 'parentElement', 'get').mockImplementation(() => $body);
+    jest.spyOn($body, 'parentElement', 'get').mockImplementation(() => $html);
+
+    unlockScroll(scrollableEl, {recursive: true});
+    expect(isScrollLocked(scrollableEl)).toBeFalsy();
+    expect(isScrollLocked($body)).toBeFalsy();
+    expect(isScrollLocked($html)).toBeFalsy();
+  });
+
+  describe('Unlock scroll with initiator', () => {
+    test('unlock with initiator', () => {
+      jest.spyOn(scrollableEl, 'removeAttribute');
+      lockScroll(scrollableEl, {initiator: 'init'});
+
+      unlockScroll(scrollableEl, {initiator: 'init'});
+      expect(scrollableEl.removeAttribute).toHaveBeenCalled();
+      expect(isScrollLocked(scrollableEl)).toBeFalsy();
+    });
+
+    test('shouldn`t unlock with wrong initiator', () => {
+      jest.spyOn(scrollableEl, 'removeAttribute');
+      lockScroll(scrollableEl, {initiator: 'init'});
+
+      unlockScroll(scrollableEl, {initiator: 'init2'});
+      expect(scrollableEl.removeAttribute).toHaveBeenCalledTimes(0);
+      expect(isScrollLocked(scrollableEl)).toBeTruthy();
+    });
+  });
+});

--- a/src/modules/esl-utils/dom/scroll/utils.ts
+++ b/src/modules/esl-utils/dom/scroll/utils.ts
@@ -44,7 +44,7 @@ export function lockScroll(target: Element = $html, options: ScrollLockOptions =
   if (initiator) {
     const initiatorList = initiatorMap.get(target);
     if (initiatorList) {
-      if (initiatorList.indexOf(initiator) >= 0) return;
+      if (initiatorList.includes(initiator)) return;
       initiatorList.push(initiator);
       if (initiatorList.length > 1) return;
     } else {

--- a/src/modules/esl-utils/dom/scroll/utils.ts
+++ b/src/modules/esl-utils/dom/scroll/utils.ts
@@ -1,7 +1,7 @@
 import {getScrollParent} from './parent';
 
 const $html = document.documentElement;
-const initiatorSet = new Set();
+const initiatorMap = new Map();
 
 /** Checks if element is blocked from scrolling */
 export function isScrollLocked(target: Element): boolean {
@@ -40,8 +40,8 @@ export type ScrollLockOptions = {
  * */
 export function lockScroll(target: Element = $html, options: ScrollLockOptions = {}): void {
   if (options.initiator) {
-    initiatorSet.add(options.initiator);
-    if (initiatorSet.size === 0) return;
+    if (initiatorMap.get(target)) return;
+    initiatorMap.set(target, options.initiator);
   }
 
   const scrollable = target === $html ? target : getScrollParent(target);
@@ -52,15 +52,14 @@ export function lockScroll(target: Element = $html, options: ScrollLockOptions =
 /**
  * Enables scroll on the target element in case it was requested with given initiator.
  * @param target - scrollable element
- * @param options - additional options to lock scroll
+ * @param options - additional options to unlock scroll
  */
 export function unlockScroll(target: Element = $html, options: ScrollLockOptions = {}): void {
   if (options.initiator) {
-    initiatorSet.delete(options.initiator);
-    if (initiatorSet.size > 0) return;
-  } else {
-    initiatorSet.clear();
+    const initiator = initiatorMap.get(target);
+    if (initiator !== options.initiator) return;
   }
+  initiatorMap.delete(target);
 
   const scrollable = target === $html ? target : getScrollParent(target);
   scrollable.removeAttribute('esl-scroll-lock');


### PR DESCRIPTION
In the scope of this PR:
- covered scroll utils with tests (except scrollIntoView function, because it's implementation will be changed in future updates);
- renamed function from 'isScrollParent' to 'isScrollable', because it didn't actually check element's parent element;
- replaced initiatorSet with initiatorMap in order for it to remember initiator target.