### PR TITLE
feat(esl-utils): extend SynteticEventTarget with ability to separate events enhancement

### DIFF
--- a/src/modules/esl-utils/dom/events/test/target.test.ts
+++ b/src/modules/esl-utils/dom/events/test/target.test.ts
@@ -1,66 +1,120 @@
 import {SyntheticEventTarget} from '../target';
 
 describe('dom/events: SyntheticEventTarget', () => {
-  describe('handler function', () => {
+  describe('Handler function', () => {
     const et = new SyntheticEventTarget();
 
-    test('basic', () => {
+    describe('Basic functionality', () => {
       const event1 = new CustomEvent('change');
       const event2 = new CustomEvent('change');
       const event3 = new CustomEvent('change');
+      const event4 = new CustomEvent('click');
+
       const listener = jest.fn();
       et.addEventListener('change', listener);
 
-      expect(listener).toBeCalledTimes(0);
-      et.dispatchEvent(event1);
-      expect(listener).toBeCalledWith(event1);
-      et.dispatchEvent(event2);
-      expect(listener).toHaveBeenLastCalledWith(event2);
-      et.removeEventListener('change', listener);
-      et.dispatchEvent(event3);
-      expect(listener).toBeCalledTimes(2);
+      test('listener shoudn`t be called', () => expect(listener).toBeCalledTimes(0));
+
+      test('listener should be called once', () => {
+        et.dispatchEvent(event1);
+        expect(listener).toBeCalledWith(event1);
+      });
+
+      test('listener should be called two times', () => {
+        et.dispatchEvent(event2);
+        expect(listener).toHaveBeenLastCalledWith(event2);
+      });
+
+      test('listener shouldn`t be called for event it`s not subscribed to', () => {
+        et.dispatchEvent(event4);
+        expect(listener).toHaveBeenLastCalledWith(event2);
+      });
+
+      test('listener should be stored', () => {
+        expect(et.hasEventListener('change')).toBe(true);
+      });
+
+      test('target shouldn`t have more listeners than it actually has', () => {
+        expect(et.hasEventListener('change', 3)).toBe(false);
+      });
+
+      test('listener shouldn`t be stored for wrong event type', () => {
+        expect(et.hasEventListener('change2')).toBe(false);
+      });
+
+      test('listener shouldn`t be called third time', () => {
+        et.removeEventListener('change', listener);
+        et.dispatchEvent(event3);
+        expect(listener).toBeCalledTimes(2);
+      });
+
+      afterAll(() => jest.clearAllMocks());
     });
 
-    test('short', () => {
+    describe('Shorthand API', () => {
       const event1 = new CustomEvent('change');
       const event2 = new CustomEvent('change');
+
       const listener = jest.fn();
       et.addEventListener(listener);
 
-      expect(listener).toBeCalledTimes(0);
-      et.dispatchEvent(event1);
-      expect(listener).toBeCalledWith(event1);
-      et.removeEventListener(listener);
-      et.dispatchEvent(event2);
-      expect(listener).toBeCalledTimes(1);
+      test('listener shoudn`t be called', () => expect(listener).toBeCalledTimes(0));
+
+      test('listener should be called once', () => {
+        et.dispatchEvent(event1);
+        expect(listener).toBeCalledWith(event1);
+      });
+
+      test('listener should be stored', () => {
+        expect(et.hasEventListener()).toBe(true);
+      });
+
+      test('target shouldn`t have more listeners than it actually has', () => {
+        expect(et.hasEventListener(2)).toBe(false);
+      });
+
+      test('listener shouldn`t be called second time', () => {
+        et.removeEventListener(listener);
+        et.dispatchEvent(event2);
+        expect(listener).toBeCalledTimes(1);
+      });
+
+      afterAll(() => jest.clearAllMocks());
     });
 
-    test('legacy fn', () => {
+    describe('Legacy functionality', () => {
       const event1 = new CustomEvent('change');
       const event2 = new CustomEvent('change');
       const listener = jest.fn();
       et.addListener(listener);
 
-      expect(listener).toBeCalledTimes(0);
-      et.dispatchEvent(event1);
-      expect(listener).toBeCalledWith(event1);
-      et.removeListener(listener);
-      et.dispatchEvent(event2);
-      expect(listener).toBeCalledTimes(1);
+      test('listener shoudn`t be called', () => expect(listener).toBeCalledTimes(0));
+
+      test('listener should be called once', () => {
+        et.dispatchEvent(event1);
+        expect(listener).toBeCalledWith(event1);
+      });
+
+      test('listener shouldn`t be called second time', () => {
+        et.removeListener(listener);
+        et.dispatchEvent(event2);
+        expect(listener).toBeCalledTimes(1);
+      });
     });
 
-    test('api restriction', () => {
+    describe('API restriction', () => {
       // @ts-ignore
-      expect(() => et.addEventListener()).toThrowError();
-      expect(() => et.addEventListener(null as any)).toThrowError();
-      expect(() => et.addEventListener(1 as any)).toThrowError();
+      test('should fail without params', () => expect(() => et.addEventListener()).toThrowError());
+      test('should fail with null passed as param', () => expect(() => et.addEventListener(null as any)).toThrowError());
+      test('should fail with number passed as param', () => expect(() => et.addEventListener(1 as any)).toThrowError());
+      test('should fail with string passed as callback', () => expect(() => et.addEventListener('change', 'click' as any)).toThrowError());
     });
   });
 
   describe('handler object', () => {
     const et = new SyntheticEventTarget();
 
-    test('basic', () => {
+    describe('Basic functionality', () => {
       const event1 = new CustomEvent('change');
       const event2 = new CustomEvent('change');
       const event3 = new CustomEvent('change');
@@ -69,56 +123,74 @@ describe('dom/events: SyntheticEventTarget', () => {
       };
       et.addEventListener('change', listener);
 
-      expect(listener.handleEvent).toBeCalledTimes(0);
-      et.dispatchEvent(event1);
-      expect(listener.handleEvent).toBeCalledWith(event1);
-      et.dispatchEvent(event2);
-      expect(listener.handleEvent).toHaveBeenLastCalledWith(event2);
-      et.removeEventListener('change', listener);
-      et.dispatchEvent(event3);
-      expect(listener.handleEvent).toBeCalledTimes(2);
+      test('listener event handler shoudn`t be called', () => expect(listener.handleEvent).toBeCalledTimes(0));
+
+      test('listener event handler should be called once', () => {
+        et.dispatchEvent(event1);
+        expect(listener.handleEvent).toBeCalledWith(event1);
+      });
+
+      test('listener event handler should be called second time', () => {
+        et.dispatchEvent(event2);
+        expect(listener.handleEvent).toHaveBeenLastCalledWith(event2);
+      });
+
+      test('listener event handler shouldn`t be called third time', () => {
+        et.removeEventListener('change', listener);
+        et.dispatchEvent(event3);
+        expect(listener.handleEvent).toBeCalledTimes(2);
+      });
     });
 
-    test('short', () => {
+    describe('Short api', () => {
       const event1 = new CustomEvent('change');
       const event2 = new CustomEvent('change');
       const listener = {
         handleEvent: jest.fn()
       };
-      et.addEventListener(listener);
 
-      expect(listener.handleEvent).toBeCalledTimes(0);
-      et.dispatchEvent(event1);
-      expect(listener.handleEvent).toBeCalledWith(event1);
-      et.removeEventListener(listener);
-      et.dispatchEvent(event2);
-      expect(listener.handleEvent).toBeCalledTimes(1);
+      test('listener event handler shoudn`t be called', () => {
+        et.addEventListener(listener);
+        expect(listener.handleEvent).toBeCalledTimes(0);});
+
+      test('listener event handler should be called once', () => {
+        et.dispatchEvent(event1);
+        expect(listener.handleEvent).toBeCalledWith(event1);
+      });
+
+      test('listener event handler shouldn`t be called second time', () => {
+        et.removeEventListener(listener);
+        et.dispatchEvent(event2);
+        expect(listener.handleEvent).toBeCalledTimes(1);
+      });
     });
 
-    test('api restriction', () => {
-      expect(() => et.addEventListener({} as any)).toThrowError();
-    });
+    test('api restriction', () => expect(() => et.addEventListener({} as any)).toThrowError());
   });
 
-  describe('preventDefault', () => {
-    test('not prevented', () => {
+  describe('PreventDefault', () => {
+    describe('Event action not prevented', () => {
       const et = new SyntheticEventTarget();
       const listener = jest.fn(() => {});
-
       et.addEventListener('change', listener);
-      const result = et.dispatchEvent(new Event('change', {cancelable: true}));
-      expect(listener).toBeCalled();
-      expect(result).toBe(false);
+
+      test('event shouldn`t be prevented', () => {
+        const result = et.dispatchEvent(new Event('change', {cancelable: true}));
+        expect(listener).toBeCalled();
+        expect(result).toBe(false);
+      });
     });
 
-    test('prevented', () => {
+    describe('Event action prevented', () => {
       const et = new SyntheticEventTarget();
       const listener = jest.fn((e: Event) => {e.preventDefault();});
-
       et.addEventListener('change', listener);
-      const result = et.dispatchEvent(new Event('change', {cancelable: true}));
-      expect(listener).toBeCalled();
-      expect(result).toBe(true);
+
+      test('preventDefault method should work correctly', () => {
+        const result = et.dispatchEvent(new Event('change', {cancelable: true}));
+        expect(listener).toBeCalled();
+        expect(result).toBe(true);
+      });
     });
   });
 });

--- a/src/modules/esl-utils/dom/events/test/target.test.ts
+++ b/src/modules/esl-utils/dom/events/test/target.test.ts
@@ -2,9 +2,9 @@ import {SyntheticEventTarget} from '../target';
 
 describe('dom/events: SyntheticEventTarget', () => {
   describe('Handler function', () => {
-    const et = new SyntheticEventTarget();
-
     describe('Basic functionality', () => {
+      const et = new SyntheticEventTarget();
+
       const event1 = new CustomEvent('change');
       const event2 = new CustomEvent('change');
       const event3 = new CustomEvent('change');
@@ -31,15 +31,15 @@ describe('dom/events: SyntheticEventTarget', () => {
       });
 
       test('listener should be stored', () => {
-        expect(et.hasEventListener('change')).toBe(true);
+        expect(et.hasEventListener('change', 0)).toBe(true);
       });
 
       test('target shouldn`t have more listeners than it actually has', () => {
-        expect(et.hasEventListener('change', 3)).toBe(false);
+        expect(et.hasEventListener('change', 1)).toBe(false);
       });
 
       test('listener shouldn`t be stored for wrong event type', () => {
-        expect(et.hasEventListener('change2')).toBe(false);
+        expect(et.hasEventListener('change2', 0)).toBe(false);
       });
 
       test('listener shouldn`t be called third time', () => {
@@ -52,6 +52,8 @@ describe('dom/events: SyntheticEventTarget', () => {
     });
 
     describe('Shorthand API', () => {
+      const et = new SyntheticEventTarget();
+
       const event1 = new CustomEvent('change');
       const event2 = new CustomEvent('change');
 
@@ -65,12 +67,22 @@ describe('dom/events: SyntheticEventTarget', () => {
         expect(listener).toBeCalledWith(event1);
       });
 
-      test('listener should be stored', () => {
-        expect(et.hasEventListener()).toBe(true);
+      describe('Listener should be stored', () => {
+        test('should be valid to pass only event type', () => {
+          expect(et.hasEventListener('change')).toBe(true);
+        });
+
+        test('should be valid without passing any of the parameters', () => {
+          expect(et.hasEventListener()).toBe(true);
+        });
+      });
+
+      test('listener shouldn`t be stored for wrong event type', () => {
+        expect(et.hasEventListener('change2')).toBe(false);
       });
 
       test('target shouldn`t have more listeners than it actually has', () => {
-        expect(et.hasEventListener(2)).toBe(false);
+        expect(et.hasEventListener(1)).toBe(false);
       });
 
       test('listener shouldn`t be called second time', () => {
@@ -83,6 +95,8 @@ describe('dom/events: SyntheticEventTarget', () => {
     });
 
     describe('Legacy functionality', () => {
+      const et = new SyntheticEventTarget();
+
       const event1 = new CustomEvent('change');
       const event2 = new CustomEvent('change');
       const listener = jest.fn();
@@ -103,6 +117,7 @@ describe('dom/events: SyntheticEventTarget', () => {
     });
 
     describe('API restriction', () => {
+      const et = new SyntheticEventTarget();
       // @ts-ignore
       test('should fail without params', () => expect(() => et.addEventListener()).toThrowError());
       test('should fail with null passed as param', () => expect(() => et.addEventListener(null as any)).toThrowError());
@@ -191,6 +206,21 @@ describe('dom/events: SyntheticEventTarget', () => {
         expect(listener).toBeCalled();
         expect(result).toBe(true);
       });
+    });
+  });
+
+  describe('Listener duplicate subscription', () => {
+    const et = new SyntheticEventTarget();
+    const listener = jest.fn(() => {});
+
+    test('event should be subscribed', () => {
+      et.addEventListener('change', listener);
+      expect(et.hasEventListener(1)).toBe(false);
+    });
+
+    test('event shouldn`t be subscribed again', () => {
+      et.addEventListener('change', listener);
+      expect(et.hasEventListener(1)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
In the scope of this PR I extended SynteticEventTarget to separate events by their type.
The end result repeats implementation of native event storage.
Code base tests were extended and refactored.