### PR TITLE
fix(esl-traversing-query): add comma to use multiple target

### DIFF
--- a/src/modules/esl-traversing-query/core/esl-traversing-query.ts
+++ b/src/modules/esl-traversing-query/core/esl-traversing-query.ts
@@ -96,7 +96,38 @@ export class TraversingQuery {
     return uniq(result);
   }
 
+  private static splitByComma = {
+    [Symbol.split](str: string): string[] {
+      let pos = 0;
+      let isInsideBrackets = false;
+      const comma = ',';
+      const openBracket = '(';
+      const closingBracket = ')';
+
+      const result = [];
+
+      for (let i = 0; i < str.length; i++) {
+        if (str[i] === openBracket) {
+          isInsideBrackets = true;
+        } else if (str[i] === closingBracket) {
+          isInsideBrackets = false;
+        }
+        if (str[i] === comma && !isInsideBrackets) {
+          result.push(str.substring(pos, i).trim());
+          pos = i + 1;
+        } else if (i === str.length - 1) {
+          result.push(str.substring(pos, i + 1).trim());
+        }
+      }
+      return result;
+    }
+  };
+
   static traverse(query: string, findFirst: boolean, base?: Element | null, scope: Element | Document = document): Element[] {
+    const parts = query.split(TraversingQuery.splitByComma);
+    return parts.map(p => this.traverseOne(p, findFirst, base, scope)).reduce((p, c) => p.concat(c), []);
+  }
+  private static traverseOne(query: string, findFirst: boolean, base?: Element | null, scope: Element | Document = document): Element[] {
     const parts = query.split(this.PROCESSORS_REGEX).map((term) => term.trim());
     const rootSel = parts.shift();
     const baseCollection = base ? [base] : [];

--- a/src/modules/esl-traversing-query/test/esl-traversing-query.test.ts
+++ b/src/modules/esl-traversing-query/test/esl-traversing-query.test.ts
@@ -169,4 +169,13 @@ describe('Traversing Query tests', () => {
         .toEqual(expectedCollection);
     });
   });
+  describe('select multiple DOM elements via esl-traversing-query using comma', () => {
+    test.each([
+      ['::parent,::next', btn1, [row1, btn2]],
+      ['::next,::parent', btn1, [btn2, row1]],
+      ['::parent,::next', btn2, [row1, btn3]],
+      ['::find(button, article)::filter(:first-child)', row1, [btn1]],
+      ['::find(button, article)::filter(:last-child)', row1, [article1]],
+    ])('Main check: TraversingQuery.all/one, Sel: %s, Base: %p.', traversingQueryWrap);
+  });
 });


### PR DESCRIPTION

Add possibility to select multiple DOM elements via esl-traversing-query using comma as separating character.

Closes: #1102