### PR TITLE
feat(esl-utility): event listener subscription logic fix and ability to inherit listener definition

### DIFF
--- a/src/modules/esl-base-element/core.ts
+++ b/src/modules/esl-base-element/core.ts
@@ -2,6 +2,7 @@ export type {ESLBaseElementShape} from './core/esl-base-element.shape';
 
 export * from './core/esl-base-element';
 
+export * from '../esl-utils/decorators/prop';
 export * from '../esl-utils/decorators/attr';
 export * from '../esl-utils/decorators/bool-attr';
 export * from '../esl-utils/decorators/json-attr';

--- a/src/modules/esl-mixin-element/core.ts
+++ b/src/modules/esl-mixin-element/core.ts
@@ -1,5 +1,6 @@
 export * from './ui/esl-mixin-element';
 
+export * from '../esl-utils/decorators/prop';
 export * from '../esl-utils/decorators/attr';
 export * from '../esl-utils/decorators/bool-attr';
 export * from '../esl-utils/decorators/json-attr';

--- a/src/modules/esl-utils/decorators/listen.ts
+++ b/src/modules/esl-utils/decorators/listen.ts
@@ -7,13 +7,13 @@ type ListenDecorator<EType extends Event> =
   (target: any, property: string, descriptor: TypedPropertyDescriptor<ESLListenerHandler<EType>>) => void;
 
 type ESLListenerDescriptorExt<T extends keyof ESLListenerEventMap = string> = Partial<ESLListenerDescriptor<T>> & {
-  /** Defines if the listener metadata should be inherited from the method of super class */
+  /** Defines if the listener metadata should be inherited from the method of the superclass */
   inherit?: boolean;
 };
 
 /**
  * Decorator to declare listener ({@link ESLEventListener}) meta information
- * Note no argument `@listen` decorator declares listener interpreted from the superclass
+ * `@listen` decorator without arguments declares a listener that is inherited from the superclass
  */
 export function listen(): ListenDecorator<Event>;
 /**

--- a/src/modules/esl-utils/decorators/listen.ts
+++ b/src/modules/esl-utils/decorators/listen.ts
@@ -6,6 +6,16 @@ import type {ESLListenerHandler, ESLListenerEventMap, ESLListenerDescriptor} fro
 type ListenDecorator<EType extends Event> =
   (target: any, property: string, descriptor: TypedPropertyDescriptor<ESLListenerHandler<EType>>) => void;
 
+type ESLListenerDescriptorExt<T extends keyof ESLListenerEventMap = string> = Partial<ESLListenerDescriptor<T>> & {
+  /** Defines if the listener metadata should be inherited from the method of super class */
+  inherit?: boolean;
+};
+
+/**
+ * Decorator to declare listener ({@link ESLEventListener}) meta information
+ * Note no argument `@listen` decorator declares listener interpreted from the superclass
+ */
+export function listen(): ListenDecorator<Event>;
 /**
  * Decorator to declare listener ({@link ESLEventListener}) meta information
  * Defines auto-subscribable event
@@ -17,14 +27,15 @@ export function listen<K extends keyof ESLListenerEventMap>(event: K | PropertyP
  * Defines auto-subscribable event by default
  * @param desc - event listener configuration {@link ESLListenerDescriptor}
  */
-export function listen<K extends keyof ESLListenerEventMap>(desc: ESLListenerDescriptor<K>): ListenDecorator<ESLListenerEventMap[K]>;
+export function listen<K extends keyof ESLListenerEventMap>(desc: ESLListenerDescriptorExt<K>): ListenDecorator<ESLListenerEventMap[K]>;
 
-export function listen(desc: string | ESLListenerDescriptor): ListenDecorator<Event> {
+export function listen(desc: string | ESLListenerDescriptorExt = {inherit: true}): ListenDecorator<Event> {
   return function listener<T extends ESLListenerHandler>(target: HTMLElement,
                                                          propertyKey: string,
                                                          descriptor: TypedPropertyDescriptor<T>): void {
+    const superDesc = Object.getPrototypeOf(target)[propertyKey];
     desc = typeof desc === 'string' || typeof desc === 'function' ? {event: desc} : desc;
-    desc = Object.assign({auto: true}, desc);
+    desc = Object.assign({auto: true}, desc.inherit && isDescriptorFn(superDesc) ? superDesc : {}, desc);
 
     if (!descriptor || typeof descriptor.value !== 'function') {
       throw new TypeError('Only class methods can be decorated via listener decorator');

--- a/src/modules/esl-utils/decorators/listen.ts
+++ b/src/modules/esl-utils/decorators/listen.ts
@@ -13,11 +13,6 @@ type ESLListenerDescriptorExt<T extends keyof ESLListenerEventMap = string> = Pa
 
 /**
  * Decorator to declare listener ({@link ESLEventListener}) meta information
- * `@listen` decorator without arguments declares a listener that is inherited from the superclass
- */
-export function listen(): ListenDecorator<Event>;
-/**
- * Decorator to declare listener ({@link ESLEventListener}) meta information
  * Defines auto-subscribable event
  * @param event - event type string or event provider function
  */
@@ -29,7 +24,7 @@ export function listen<K extends keyof ESLListenerEventMap>(event: K | PropertyP
  */
 export function listen<K extends keyof ESLListenerEventMap>(desc: ESLListenerDescriptorExt<K>): ListenDecorator<ESLListenerEventMap[K]>;
 
-export function listen(desc: string | ESLListenerDescriptorExt = {inherit: true}): ListenDecorator<Event> {
+export function listen(desc: string | ESLListenerDescriptorExt): ListenDecorator<Event> {
   return function listener<T extends ESLListenerHandler>(target: HTMLElement,
                                                          propertyKey: string,
                                                          descriptor: TypedPropertyDescriptor<T>): void {

--- a/src/modules/esl-utils/decorators/test/listen.test.ts
+++ b/src/modules/esl-utils/decorators/test/listen.test.ts
@@ -29,7 +29,7 @@ describe('Decorator: @listen', () => {
     expect(typeof EventUtils.descriptors(test)[0].event).toBe('function');
   });
 
-  test('Multiple @listen declarations auto-subscribed correctly with a full event definition', () => {
+  test('Multiple @listen declarations should be auto-subscribed correctly with a full event definition', () => {
     class Test extends HTMLElement {
       @listen({event: 'event1'})
       onEvent1() {}
@@ -42,7 +42,7 @@ describe('Decorator: @listen', () => {
     expect(EventUtils.descriptors(test).length).toBe(2);
   });
 
-  test('Event listener definitions from the super class handled correctly', () => {
+  test('Event listener definitions from the superclass should be handled correctly', () => {
     class Test extends HTMLElement {
       @listen({event: 'event1'})
       onEvent1() {}
@@ -57,7 +57,7 @@ describe('Decorator: @listen', () => {
     expect(EventUtils.descriptors(test).length).toBe(2);
   });
 
-  test('Override event listener definition without decorator exclude subscription', () => {
+  test('Override event listener definition without decorator should exclude subscription', () => {
     class Test extends HTMLElement {
       @listen({event: 'event1'})
       onEvent() {}
@@ -87,7 +87,7 @@ describe('Decorator: @listen', () => {
     expect((test.onEvent as any as ESLListenerDescriptorFn).event).toBe('event1');
   });
 
-  test('Override event listener definition with a @listen({inherit: true, ...}) merge event description meta information', () => {
+  test('Override event listener definition with a @listen({inherit: true, ...}) should merge event description meta information', () => {
     class Test extends HTMLElement {
       @listen({event: 'event1', selector: 'e'})
       onEvent() {}

--- a/src/modules/esl-utils/decorators/test/listen.test.ts
+++ b/src/modules/esl-utils/decorators/test/listen.test.ts
@@ -2,9 +2,10 @@ import '../../../../polyfills/es5-target-shim';
 
 import {listen} from '../listen';
 import {EventUtils} from '../../dom/events';
+import type {ESLListenerDescriptorFn} from '../../dom/events';
 
-describe('Decorator: listen', () => {
-  test('short', () => {
+describe('Decorator: @listen', () => {
+  test('Decorator listen should accept one argument call with an event type', () => {
     class Test extends HTMLElement {
       @listen('click')
       onEvent() {}
@@ -16,7 +17,7 @@ describe('Decorator: listen', () => {
     expect(EventUtils.descriptors(test)[0].event).toBe('click');
   });
 
-  test('provider', () => {
+  test('Decorator listen should accept one argument call with an event type provider', () => {
     class Test extends HTMLElement {
       @listen(() => 'test')
       onEvent() {}
@@ -28,7 +29,7 @@ describe('Decorator: listen', () => {
     expect(typeof EventUtils.descriptors(test)[0].event).toBe('function');
   });
 
-  test('full', () => {
+  test('Multiple @listen declarations auto-subscribed correctly with a full event definition', () => {
     class Test extends HTMLElement {
       @listen({event: 'event1'})
       onEvent1() {}
@@ -41,7 +42,7 @@ describe('Decorator: listen', () => {
     expect(EventUtils.descriptors(test).length).toBe(2);
   });
 
-  test('inheritance', () => {
+  test('Event listener definitions from the super class handled correctly', () => {
     class Test extends HTMLElement {
       @listen({event: 'event1'})
       onEvent1() {}
@@ -56,7 +57,71 @@ describe('Decorator: listen', () => {
     expect(EventUtils.descriptors(test).length).toBe(2);
   });
 
-  test('multiple decoration', () => {
+  test('Override event listener definition without decorator exclude subscription', () => {
+    class Test extends HTMLElement {
+      @listen({event: 'event1'})
+      onEvent() {}
+    }
+    class TestInh extends Test {
+      onEvent() {}
+    }
+    customElements.define('test-listen-4', TestInh);
+
+    const test = new TestInh();
+    expect(EventUtils.descriptors(test).length).toBe(0);
+  });
+
+  test('Override event listener definition with a @listen({inherit: true}) inherits event description meta information', () => {
+    class Test extends HTMLElement {
+      @listen({event: 'event1'})
+      onEvent() {}
+    }
+    class TestInh extends Test {
+      @listen({inherit: true})
+      onEvent() {}
+    }
+    customElements.define('test-listen-5', TestInh);
+
+    const test = new TestInh();
+    expect(EventUtils.descriptors(test).length).toBe(1);
+    expect((test.onEvent as any as ESLListenerDescriptorFn).event).toBe('event1');
+  });
+
+  test('Override event listener definition with a @listen({inherit: true, ...}) merge event description meta information', () => {
+    class Test extends HTMLElement {
+      @listen({event: 'event1', selector: 'e'})
+      onEvent() {}
+    }
+    class TestInh extends Test {
+      @listen({inherit: true, event: 'event2'})
+      onEvent() {}
+    }
+    customElements.define('test-listen-6', TestInh);
+
+    const test = new TestInh();
+    expect(EventUtils.descriptors(test).length).toBe(1);
+    expect((test.onEvent as any as ESLListenerDescriptorFn).event).toBe('event2');
+    expect((test.onEvent as any as ESLListenerDescriptorFn).selector).toBe('e');
+  });
+
+  test('Override event listener definition with a @listen({...}) replaces event description meta information', () => {
+    class Test extends HTMLElement {
+      @listen({event: 'event1', selector: 'e'})
+      onEvent() {}
+    }
+    class TestInh extends Test {
+      @listen({event: 'event2'})
+      onEvent() {}
+    }
+    customElements.define('test-listen-7', TestInh);
+
+    const test = new TestInh();
+    expect(EventUtils.descriptors(test).length).toBe(1);
+    expect((test.onEvent as any as ESLListenerDescriptorFn).event).toBe('event2');
+    expect((test.onEvent as any as ESLListenerDescriptorFn).selector).toBe(undefined);
+  });
+
+  test('Decorator @listen can not be applied multiple times to the same function', () => {
     expect(() => {
       class Test extends HTMLElement {
         @listen({event: 'event1'})

--- a/src/modules/esl-utils/dom/events/listener.ts
+++ b/src/modules/esl-utils/dom/events/listener.ts
@@ -162,6 +162,9 @@ export class ESLEventListener implements ESLListenerDescriptor, EventListenerObj
   /** Creates event listeners by handler and descriptors */
   public static create(target: HTMLElement, handler: ESLListenerHandler, desc: ESLListenerDescriptor): ESLEventListener[] {
     const events = resolveProperty(desc.event, desc.context || target);
+    if (!events.length) {
+      console.warn('[ESL]: Can\'t create ESLEventListener with empty event type: %o %o', handler, desc);
+    }
     return ESLEventListener.splitEventQ(events).map((event) => {
       const spec: ESLListenerDescriptor = Object.assign({}, desc, {event});
       return new ESLEventListener(target, handler, spec);

--- a/src/modules/esl-utils/dom/events/listener.ts
+++ b/src/modules/esl-utils/dom/events/listener.ts
@@ -129,13 +129,18 @@ export class ESLEventListener implements ESLListenerDescriptor, EventListenerObj
     return current.contains(target.closest(this.selector));
   }
 
-  /** (Re-)Subscribes event listener instance */
-  public subscribe(): void {
+  /**
+   * (Re-)Subscribes event listener instance
+   * @returns if subscription was successful
+   */
+  public subscribe(): boolean {
     const {passive, capture} = this;
     this.unsubscribe();
     memoize.clear(this, '$targets');
+    if (!this.$targets.length) return false;
     this.$targets.forEach((el: EventTarget) => el.addEventListener(this.event, this, {passive, capture}));
     ESLEventListener.get(this.$host).push(this);
+    return true;
   }
 
   /** Unsubscribes event listener instance */

--- a/src/modules/esl-utils/dom/events/test/listener.test.ts
+++ b/src/modules/esl-utils/dom/events/test/listener.test.ts
@@ -14,6 +14,18 @@ describe('dom/events: ESLEventListener', () => {
   });
 
   describe('create', () => {
+    test('without event type', () => {
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => void 0);
+
+      const host = document.createElement('div');
+      const handler = jest.fn();
+      const result = ESLEventListener.create(host, handler, {event: ''});
+
+      expect(result.length).toBe(0);
+      expect(consoleSpy).toBeCalledTimes(1);
+      consoleSpy.mockClear();
+    });
+
     test('one by string', () => {
       const host = document.createElement('div');
       const handler = jest.fn();

--- a/src/modules/esl-utils/dom/events/test/utils.test.ts
+++ b/src/modules/esl-utils/dom/events/test/utils.test.ts
@@ -89,6 +89,16 @@ describe('dom/events: EventUtils', () => {
       expect(createMock).toBeCalledWith(host, expect.anything(), expect.anything());
     });
 
+    test('decorated handler with empty override', () => {
+      const host = {};
+      const createMock =
+        jest.spyOn(ESLEventListener, 'create').mockImplementation((el, cb, desc) => [desc] as any);
+
+      EventUtils.subscribe(host as any, {}, listener1);
+      expect(listener1.subscribe).toBeCalled();
+      expect(createMock).toBeCalledWith(host, expect.anything(), expect.anything());
+    });
+
     test('merge decorated handler', () => {
       const host = {};
       const createMock =


### PR DESCRIPTION
In bounds of this PR:
1. Add a check to prevent an empty targets listener from subscription
2. Make able to inherit event listener method definition meta from superclass with a short version of `@listen` decorator
3. (cosmetic) `prop` decorator added to the `esl-mixin-element` and `esl-base-element` modules export
4. cover new functionality by tests

The following inheritance cases are available :
For now the following syntax is available:
```
class Super {
   @listen({...})
   onEvent() {}
}

// Unsubscribe option 
class ClassA {
   // overrides without listener definition
   onEvent() {}
}

// Replaces Super definition
class ClassB {
   @listen({...})
   onEvent() {}
}

// Inherit and merge Super event listener definition
class ClassC {
   @listen({inherit: true, ...})
   onEvent() {}
}

// Just inherit Super event listener definition
class ClassD {
   @listen({inherit: true})
   onEvent() {}
}

// Sort version to just inherit Super event listener definition
class ClassE {
   @listen()
   onEvent() {}
}
```

----

@exadel-inc/esl-all-contributors, please feel free to leave feedback about the current implementation.

Also, please take a look at the inheritance use cases described above, and please let me know:

1. Is this behavior looks safe and intuitive for you in general?
(Short emoji: 👍🏻(yes) / 👎🏻 (no) )
2. Do we need to have a short version to inherit listener metadata,
or we should restrict case of ClassE to the full version (ClassD)
(Short emoji: 🚀 (short version ok) / 😕 (short version confused) )