### PR TITLE
code style: disallow number leading zero

### DIFF
--- a/.stylelintrc.yml
+++ b/.stylelintrc.yml
@@ -50,6 +50,8 @@ rules:
   # Disallow double-slash comments `(//...)` for clear CSS, as they are not supported by CSS
   # and could lead to unexpected results
   no-invalid-double-slash-comments: true
+  # Disallow a leading zero for fractional numbers less than 1
+  number-leading-zero: never
   # Disallow unknown properties
   property-no-unknown: true
   # Disallow whitespace before the commas of selector lists

--- a/pages/src/banner/banner.less
+++ b/pages/src/banner/banner.less
@@ -15,11 +15,11 @@
     font-weight: 500;
 
     p {
-      margin: 0.05rem;
+      margin: .05rem;
     }
 
     @media @xs-sm {
-      font-size: 0.85rem;
+      font-size: .85rem;
     }
   }
 }

--- a/pages/src/common/accordion.less
+++ b/pages/src/common/accordion.less
@@ -10,9 +10,9 @@
   background-clip: border-box;
 
   border: 1px solid @secondary-blue;
-  border-radius: 0.3rem;
+  border-radius: .3rem;
 
-  margin-bottom: 0.5em;
+  margin-bottom: .5em;
 
   &-body {
     flex: 1 1 auto;
@@ -20,14 +20,14 @@
   }
 
   &-header {
-    padding: 0.75rem 1.25rem;
+    padding: .75rem 1.25rem;
     margin-bottom: 0;
 
     border-bottom: 1px solid transparent;
     transition: border-bottom-color .4s ease-in-out;
 
     &:first-child {
-      border-radius: calc(0.25rem - 1px) calc(0.25rem - 1px) 0 0;
+      border-radius: calc(.25rem - 1px) calc(.25rem - 1px) 0 0;
     }
 
     &-arrow {

--- a/pages/src/common/alert.less
+++ b/pages/src/common/alert.less
@@ -2,10 +2,10 @@
 
 .alert {
   position: relative;
-  padding: 0.75rem 1.25rem;
+  padding: .75rem 1.25rem;
   margin-bottom: 1rem;
   border: 1px solid transparent;
-  border-radius: 0.25rem;
+  border-radius: .25rem;
 
   .alert-color(@cls, @color) {
     &-@{cls} {

--- a/pages/src/common/badge.less
+++ b/pages/src/common/badge.less
@@ -2,25 +2,25 @@
 
 .badge {
   display: inline-block;
-  padding: 0.25em 0.4em;
+  padding: .25em .4em;
   font-size: 75%;
   font-weight: 700;
   line-height: 1;
   text-align: center;
   white-space: nowrap;
   vertical-align: baseline;
-  border-radius: 0.25rem;
-  transition: color 0.15s ease-in-out,
-              background-color 0.15s ease-in-out,
-              border-color 0.15s ease-in-out,
-              box-shadow 0.15s ease-in-out;
+  border-radius: .25rem;
+  transition: color .15s ease-in-out,
+              background-color .15s ease-in-out,
+              border-color .15s ease-in-out,
+              box-shadow .15s ease-in-out;
 
   &:empty {
     display: none;
   }
 
   &-md {
-    padding: 0.4em 0.8em;
+    padding: .4em .8em;
     font-size: 80%;
   }
 

--- a/pages/src/common/buttons.less
+++ b/pages/src/common/buttons.less
@@ -11,18 +11,18 @@
   user-select: none;
 
   border: 1px solid transparent;
-  border-radius: 0.75rem;
+  border-radius: .75rem;
   background-color: transparent;
 
-  padding: 0.4rem 1rem;
+  padding: .4rem 1rem;
 
   font-size: 1rem;
   line-height: 1.5;
 
-  transition: color 0.15s ease-in-out,
-              background-color 0.15s ease-in-out,
-              border-color 0.15s ease-in-out,
-              box-shadow 0.15s ease-in-out;
+  transition: color .15s ease-in-out,
+              background-color .15s ease-in-out,
+              border-color .15s ease-in-out,
+              box-shadow .15s ease-in-out;
 
   @media (prefers-reduced-motion: reduce) {
     transition: none;
@@ -39,7 +39,7 @@
     text-decoration: none;
   }
   &:disabled {
-    opacity: 0.65;
+    opacity: .65;
   }
 
   &-lg {
@@ -48,9 +48,9 @@
     font-weight: 500;
   }
   &-spaced {
-    padding: 0.8rem 2.75rem;
+    padding: .8rem 2.75rem;
     @media @sm {
-      padding: 0.8rem 2rem;
+      padding: .8rem 2rem;
     }
   }
 
@@ -96,10 +96,10 @@
   }
 
   &-container {
-    margin: -0.4rem;
+    margin: -.4rem;
   }
   &-container & {
-    margin: 0.4rem;
+    margin: .4rem;
   }
   &-group-centered {
     justify-content: center;

--- a/pages/src/common/dropdown-menu.less
+++ b/pages/src/common/dropdown-menu.less
@@ -30,10 +30,10 @@
     font-weight: 400;
     line-height: 1.5;
     border: 1px solid transparent;
-    border-radius: 0.25rem;
-    padding: 0.375rem 0.75rem;
+    border-radius: .25rem;
+    padding: .375rem .75rem;
 
-    transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+    transition: color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out;
   }
 
   .menu-item-arrow::after {

--- a/pages/src/common/forms.less
+++ b/pages/src/common/forms.less
@@ -3,8 +3,8 @@
 .form-control {
   display: block;
   width: 100%;
-  height: calc(1.5em + 0.75rem + 2px);
-  padding: 0.375rem 0.75rem;
+  height: calc(1.5em + .75rem + 2px);
+  padding: .375rem .75rem;
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5;
@@ -12,8 +12,8 @@
   background-color: #fff;
   background-clip: padding-box;
   border: 1px solid @secondary-blue;
-  border-radius: 0.25rem;
-  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+  border-radius: .25rem;
+  transition: border-color .15s ease-in-out, box-shadow .15s ease-in-out;
 
   @media (prefers-reduced-motion: reduce) {
     transition: none;
@@ -43,7 +43,7 @@
     background-color: #fff;
     border-color: #80bdff;
     outline: 0;
-    box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
+    box-shadow: 0 0 0 .2rem rgba(0, 123, 255, .25);
   }
 
   &:disabled {

--- a/pages/src/common/helpers.less
+++ b/pages/src/common/helpers.less
@@ -29,7 +29,7 @@
   margin: 0 !important;
   }
   &-1 {
-    margin: 0.5rem !important;
+    margin: .5rem !important;
   }
   &-2 {
     margin: 1rem !important;
@@ -48,7 +48,7 @@
   margin-bottom: 0 !important;
   }
   &-1 {
-    margin-bottom: 0.5rem !important;
+    margin-bottom: .5rem !important;
   }
   &-2 {
     margin-bottom: 1rem !important;
@@ -65,12 +65,12 @@
     margin-right: 0 !important;
   }
   &-1 {
-    margin-left: 0.25rem !important;
-    margin-right: 0.25rem !important;
+    margin-left: .25rem !important;
+    margin-right: .25rem !important;
   }
   &-2 {
-    margin-left: 0.5rem !important;
-    margin-right: 0.5rem !important;
+    margin-left: .5rem !important;
+    margin-right: .5rem !important;
   }
   &-auto {
     margin-right: auto !important;
@@ -81,7 +81,7 @@
 // Padding
 .p {
   &-2 {
-    padding: 0.5rem !important;
+    padding: .5rem !important;
   }
   &-3 {
     padding: 1rem !important;
@@ -93,17 +93,17 @@
 
 // Padding-top
 .pt-2 {
-  padding-top: 0.5rem !important;
+  padding-top: .5rem !important;
 }
 
 // Padding-bottom
 .pb-2 {
-  padding-bottom: 0.5rem !important;
+  padding-bottom: .5rem !important;
 }
 
 // Border radius
 .round {
-  border-radius: 0.5rem;
+  border-radius: .5rem;
 }
 
 // List helpers

--- a/pages/src/common/markdown.less
+++ b/pages/src/common/markdown.less
@@ -4,7 +4,7 @@
     padding-left: 1.5rem;
 
     p {
-      margin-bottom: 0.5rem;
+      margin-bottom: .5rem;
     }
 
     p:last-child {

--- a/pages/src/common/reboot.less
+++ b/pages/src/common/reboot.less
@@ -92,7 +92,7 @@ svg {
 
 label {
   display: inline-block;
-  margin-bottom: 0.5rem;
+  margin-bottom: .5rem;
 }
 
 input,

--- a/pages/src/common/tabs.less
+++ b/pages/src/common/tabs.less
@@ -2,12 +2,12 @@
 
 .esl-d-tab-group {
   &, & > .esl-d-tab-panel {
-    border-bottom-left-radius: calc(0.5rem - 1px);
-    border-bottom-right-radius: calc(0.5rem - 1px);
+    border-bottom-left-radius: calc(.5rem - 1px);
+    border-bottom-right-radius: calc(.5rem - 1px);
   }
 
   & > .esl-d-accordion-header {
-    border-radius: calc(0.5rem - 1px);
+    border-radius: calc(.5rem - 1px);
     transition: border-radius 0s linear.5s;
     &[active] {
       color: @primary-blue;
@@ -30,7 +30,7 @@
     border: 1px solid @secondary-blue;
     border-top: none;
 
-    margin-bottom: 0.5rem;
+    margin-bottom: .5rem;
   }
   > .esl-d-tab-group > .esl-d-accordion-header {
     display: block;
@@ -65,10 +65,10 @@
     background: #fff;
     border: 1px solid @secondary-blue;
 
-    border-top-left-radius: calc(0.5rem - 1px);
-    border-top-right-radius: calc(0.5rem - 1px);
+    border-top-left-radius: calc(.5rem - 1px);
+    border-top-right-radius: calc(.5rem - 1px);
 
-    margin-bottom: 0.5rem;
+    margin-bottom: .5rem;
   }
 }
 
@@ -90,8 +90,8 @@
 
   border: 1px solid transparent;
   border-bottom: none;
-  border-top-left-radius: calc(0.5rem - 1px);
-  border-top-right-radius: calc(0.5rem - 1px);
+  border-top-left-radius: calc(.5rem - 1px);
+  border-top-right-radius: calc(.5rem - 1px);
 
   &:focus, &:hover {
     @inactive-color: mix(@secondary-blue, #ccc, 50);

--- a/pages/src/common/typography.less
+++ b/pages/src/common/typography.less
@@ -20,7 +20,7 @@ p {
 h1, h2, h3, h4, h5,
 .h1, .h2, .h3, .h4, .h5 {
   margin-top: 0;
-  margin-bottom: 0.5rem;
+  margin-bottom: .5rem;
   font-weight: 500;
   line-height: 1.2;
 }

--- a/pages/src/landing/marquee/marquee.less
+++ b/pages/src/landing/marquee/marquee.less
@@ -75,7 +75,7 @@
     @media @md-xl {
       font-size: 4rem;
       max-width: 100%;
-      margin: 0 -0.1875rem 1rem;
+      margin: 0 -.1875rem 1rem;
       text-shadow: none;
     }
   }
@@ -85,7 +85,7 @@
   }
   &-slogan-line {
     font-style: italic;
-    color: rgba(255, 255, 255, 0.6);
+    color: rgba(255, 255, 255, .6);
   }
 
   &-brand {

--- a/pages/src/landing/overview/overview.less
+++ b/pages/src/landing/overview/overview.less
@@ -46,7 +46,7 @@
     }
 
     &:hover {
-      opacity: 0.5;
+      opacity: .5;
     }
   }
 

--- a/pages/src/navigation/footer/footer.less
+++ b/pages/src/navigation/footer/footer.less
@@ -49,7 +49,7 @@
     }
 
     @media @md-xl {
-      font-size: 0.875rem;
+      font-size: .875rem;
     }
   }
 
@@ -169,7 +169,7 @@
   }
 
   &-common-links {
-    font-size: 0.9rem;
+    font-size: .9rem;
   }
   &-common-links &-link {
     padding: 0 10px;

--- a/pages/src/navigation/header/header-search.less
+++ b/pages/src/navigation/header/header-search.less
@@ -14,7 +14,7 @@
       padding: 0;
       overflow: hidden;
       border: none;
-      border-radius: 0.75rem;
+      border-radius: .75rem;
 
       transition: width .5s ease-in-out;
       will-change: width;

--- a/pages/src/navigation/sidebar/sidebar-content.less
+++ b/pages/src/navigation/sidebar/sidebar-content.less
@@ -42,7 +42,7 @@ esl-d-sidebar {
     padding-left: 15px;
     overflow: hidden;
 
-    font-size: 0.95rem;
+    font-size: .95rem;
     font-weight: 600;
     line-height: 20px;
     text-transform: uppercase;

--- a/src/modules/draft/esl-carousel/plugin/esl-carousel-dots.less
+++ b/src/modules/draft/esl-carousel/plugin/esl-carousel-dots.less
@@ -8,7 +8,7 @@
     line-height: 0;
     text-align: center;
     opacity: 1;
-    transition: opacity 0.5s ease-out;
+    transition: opacity .5s ease-out;
     cursor: default;
   }
 
@@ -18,7 +18,7 @@
     height: 9px;
     margin: 0 5px;
     vertical-align: middle;
-    background: rgba(118, 118, 118, 0.5);
+    background: rgba(118, 118, 118, .5);
     border: none;
     border-radius: 24px;
     cursor: pointer;
@@ -28,7 +28,7 @@
   .active-dot {
     width: 11px;
     height: 11px;
-    background: rgba(255, 255, 255, 0.5);
+    background: rgba(255, 255, 255, .5);
     border: 1px solid #bababa;
   }
 }

--- a/src/modules/esl-forms/esl-select-list/core/esl-select-item.less
+++ b/src/modules/esl-forms/esl-select-list/core/esl-select-item.less
@@ -33,7 +33,7 @@ esl-select-item {
     transform: rotate(-45deg);
 
     opacity: 0;
-    transition: opacity 0.4s ease-in;
+    transition: opacity .4s ease-in;
   }
 
   &[selected] {

--- a/src/modules/esl-forms/esl-select/core/esl-select-dropdown.less
+++ b/src/modules/esl-forms/esl-select/core/esl-select-dropdown.less
@@ -21,7 +21,7 @@
 
   .esl-select-list {
     max-height: 50vh;
-    box-shadow: 2px 4px 4px rgba(0, 0, 0, 0.2);
+    box-shadow: 2px 4px 4px rgba(0, 0, 0, .2);
 
     .esl-select-list-container {
       margin-right: 20px;

--- a/src/modules/esl-image/core/esl-image-container.less
+++ b/src/modules/esl-image/core/esl-image-container.less
@@ -42,7 +42,7 @@
       opacity: 0;
       &[ready] {
         opacity: 1;
-        transition: opacity 0.4s;
+        transition: opacity .4s;
       }
     }
 

--- a/src/modules/esl-popup/core/esl-popup.less
+++ b/src/modules/esl-popup/core/esl-popup.less
@@ -4,7 +4,7 @@
                       @popupBorderColor: #DBDBDB,
                       @popupBorderWidth: 1px) {
   @popupArrowHalf: (@popupArrowSize / 2);
-  @popupArrowShift: (@popupArrowSize * 0.2071 - @popupBorderWidth);  // 0.2071 = (sqrt(2) - 1) / 2  (Don't ask why, it's an axiom)
+  @popupArrowShift: (@popupArrowSize * .2071 - @popupBorderWidth);  // 0.2071 = (sqrt(2) - 1) / 2  (Don't ask why, it's an axiom)
 
   .@{arrowClassName} {
     position: absolute;
@@ -61,9 +61,9 @@
     display: block;
     opacity: 0;
     visibility: hidden;
-    transition: visibility 0.5s 0.2s;
+    transition: visibility .5s .2s;
     box-sizing: border-box;
-    box-shadow: 1px 1px 5px rgba(0, 0, 0, 0.2);
+    box-shadow: 1px 1px 5px rgba(0, 0, 0, .2);
     border: @borderWidth solid @borderColor;
     background: @backgroundColor;
     cursor: default;
@@ -73,7 +73,7 @@
       z-index: @zIndex;
       opacity: 1;
       visibility: visible;
-      transition: opacity 0.15s, transform 0.2s;
+      transition: opacity .15s, transform .2s;
     }
 
     &:not([open]) {


### PR DESCRIPTION
In this PR I added a number-leading-zero rule to stylelint config to disallow a leading zero for fractional numbers less than 1.

The following pattern is considered as a problem:
a { line-height: 0.5; }
The following pattern isn't considered as a problem:
a { line-height: .5; }

Closes #1125