### PR TITLE
refactor(esl-utils): event utility cleanup

### DIFF
--- a/src/modules/esl-event-listener/core/api.ts
+++ b/src/modules/esl-event-listener/core/api.ts
@@ -1,5 +1,5 @@
 import {ExportNs} from '../../esl-utils/environment/export-ns';
-
+import {dispatchCustomEvent} from '../../esl-utils/dom/events/misc';
 import {ESLEventListener} from './listener';
 
 import type {
@@ -17,19 +17,11 @@ export const isDescriptorFn = (obj: any): obj is ESLListenerDescriptorFn =>
 @ExportNs('EventUtils')
 export class EventUtils {
   /**
-   * Dispatches custom event.
-   * Event bubbles and is cancelable by default, use `eventInit` to override that.
-   * @param el - EventTarget to dispatch event
-   * @param eventName - name of the event to dispatch
-   * @param eventInit - object that specifies characteristics of the event. See {@link CustomEventInit}
+   * Dispatches custom event. Alias for {@link dispatchCustomEvent}
+   * @see dispatchCustomEvent
    */
   public static dispatch(el: EventTarget, eventName: string, eventInit?: CustomEventInit): boolean {
-    const init = Object.assign({
-      bubbles: true,
-      composed: true,
-      cancelable: true
-    }, eventInit || {});
-    return el.dispatchEvent(new CustomEvent(eventName, init));
+    return dispatchCustomEvent(el, eventName, eventInit);
   }
 
   /** Gets descriptors from the passed object */

--- a/src/modules/esl-event-listener/core/listener.ts
+++ b/src/modules/esl-event-listener/core/listener.ts
@@ -3,7 +3,7 @@ import {resolveProperty} from '../../esl-utils/misc/functions';
 import {memoize} from '../../esl-utils/decorators/memoize';
 import {isSimilar} from '../../esl-utils/misc/object/compare';
 import {TraversingQuery} from '../../esl-traversing-query/core';
-import {isPassiveByDefault, splitEvents} from '../../esl-utils/dom/events/misc';
+import {isPassiveByDefault} from '../../esl-utils/dom/events/misc';
 
 import type {PropertyProvider} from '../../esl-utils/misc/functions';
 import type {
@@ -16,6 +16,20 @@ import type {
 
 /** Key to store listeners on the host */
 const STORE = '__listeners';
+
+/**
+ * Splits and deduplicates event string
+ * @returns array of unique events presented in events string
+ */
+export const splitEvents = (events: string): string[] => {
+  const terms = (events || '').split(' ').map((term) => term.trim());
+  const deduplicate = new Set<string>();
+  return terms.filter((term) => {
+    if (!term || deduplicate.has(term)) return false;
+    deduplicate.add(term);
+    return true;
+  });
+};
 
 /**
  * `EventListener` instance, used as an 'inner' record to process subscriptions made by `EventUtils`

--- a/src/modules/esl-event-listener/test/split.test.ts
+++ b/src/modules/esl-event-listener/test/split.test.ts
@@ -1,0 +1,32 @@
+import {splitEvents} from '../core/listener';
+
+describe('ESLEventListener: splitEvents sub-utility tests', () => {
+  test(
+    'Empty string parsed to an empty array without exceptions',
+    () => expect(splitEvents('')).toEqual([])
+  );
+  test(
+    'Single event string parsed to single event',
+    () => expect(splitEvents('abc')).toEqual(['abc'])
+  );
+  test(
+    'Single event string with extra spaces parsed to single event',
+    () => expect(splitEvents('  abc ')).toEqual(['abc'])
+  );
+  test(
+    'Multiple events string parsed to separate events',
+    () => expect(splitEvents('abc de f')).toEqual(['abc', 'de', 'f'])
+  );
+  test(
+    'Multiple events string with extra spaces parsed to separate events',
+    () => expect(splitEvents(' a b')).toEqual(['a', 'b'])
+  );
+  test(
+    'The same events count ones when parsed (two unique terms)',
+    () => expect(splitEvents(' a a b')).toEqual(['a', 'b'])
+  );
+  test(
+    'The same events count ones when parsed (one unique term)',
+    () => expect(splitEvents('a a a a a')).toEqual(['a'])
+  );
+});

--- a/src/modules/esl-event-listener/test/subscribe.test.ts
+++ b/src/modules/esl-event-listener/test/subscribe.test.ts
@@ -1,19 +1,19 @@
 import {EventUtils} from '../core';
 
 describe('EventUtils:subscribe tests', () => {
-  test('EventUtils:subscribe successfully subscribe listener by descriptor', () => {
+  test('EventUtils.subscribe successfully subscribes listener by descriptor', () => {
     const $host = document.createElement('div');
     const handle = jest.fn();
     EventUtils.subscribe($host, {event: 'click'}, handle);
     expect(EventUtils.listeners($host).length).toBe(1);
   });
-  test('EventUtils:subscribe successfully subscribe listener by event name', () => {
+  test('EventUtils.subscribe successfully subscribes listener by event name', () => {
     const $host = document.createElement('div');
     const handle = jest.fn();
     EventUtils.subscribe($host, 'click', handle);
     expect(EventUtils.listeners($host).length).toBe(1);
   });
-  test('EventUtils:subscribe successfully subscribe listener by event provider', () => {
+  test('EventUtils.subscribe successfully subscribes listener by event provider', () => {
     const $host = document.createElement('div');
     const provider = jest.fn(function () {
       expect(this).toBe($host);
@@ -25,7 +25,7 @@ describe('EventUtils:subscribe tests', () => {
     expect(provider).toBeCalledWith($host);
   });
 
-  test('EventUtils:subscribe successfully subscribe listeners by string with multiple events', () => {
+  test('EventUtils.subscribe successfully subscribes listeners by string with multiple events', () => {
     const $host = document.createElement('div');
     const handle = jest.fn();
     EventUtils.subscribe($host, 'click keydown', handle);

--- a/src/modules/esl-event-listener/test/utils.test.ts
+++ b/src/modules/esl-event-listener/test/utils.test.ts
@@ -1,24 +1,6 @@
 import {EventUtils} from '../core';
 
 describe('dom/events: EventUtils', () => {
-  describe('dispatch', () => {
-    // TODO: more tests for dispatch method
-    test('dispatches event with custom event init on the provided element', () => {
-      const el = document.createElement('div');
-      jest.spyOn(el, 'dispatchEvent');
-
-      const eventName = `click${Math.random()}`;
-      const customEventInit = {detail: Math.random()};
-      EventUtils.dispatch(el, eventName, customEventInit);
-
-      expect(el.dispatchEvent).toHaveBeenCalled();
-
-      const event: CustomEvent = (el.dispatchEvent as jest.Mock).mock.calls[0][0];
-      expect(event.type).toBe(eventName);
-      expect((event as any).detail).toBe(customEventInit.detail);
-    });
-  });
-
   // TODO: extend tests + possibly move descriptor finding to separate module?
   describe('descriptors', () => {
     test('basic test 1', () => {

--- a/src/modules/esl-utils/dom/events/misc.ts
+++ b/src/modules/esl-utils/dom/events/misc.ts
@@ -42,3 +42,19 @@ export const getOffsetPoint = (el: Element): Point => {
   const x = props.left + window.scrollX;
   return {x, y};
 };
+
+/**
+ * Dispatches custom event.
+ * Event bubbles and is cancelable by default, use `eventInit` to override that.
+ * @param el - EventTarget to dispatch event
+ * @param eventName - name of the event to dispatch
+ * @param eventInit - object that specifies characteristics of the event. See {@link CustomEventInit}
+ */
+export const dispatchCustomEvent = (el: EventTarget, eventName: string, eventInit?: CustomEventInit): boolean => {
+  const init = Object.assign({
+    bubbles: true,
+    composed: true,
+    cancelable: true
+  }, eventInit || {});
+  return el.dispatchEvent(new CustomEvent(eventName, init));
+};

--- a/src/modules/esl-utils/dom/events/misc.ts
+++ b/src/modules/esl-utils/dom/events/misc.ts
@@ -42,17 +42,3 @@ export const getOffsetPoint = (el: Element): Point => {
   const x = props.left + window.scrollX;
   return {x, y};
 };
-
-/**
- * Splits and deduplicates event string
- * @returns array of unique events presented in events string
- */
-export const splitEvents = (events: string): string[] => {
-  const terms = (events || '').split(' ').map((term) => term.trim());
-  const deduplicate = new Set<string>();
-  return terms.filter((term) => {
-    if (!term || deduplicate.has(term)) return false;
-    deduplicate.add(term);
-    return true;
-  });
-};

--- a/src/modules/esl-utils/dom/events/test/misc.test.ts
+++ b/src/modules/esl-utils/dom/events/test/misc.test.ts
@@ -5,7 +5,8 @@ import {
   isPassiveByDefault,
   getTouchPoint,
   getOffsetPoint,
-  getCompositeTarget
+  getCompositeTarget,
+  dispatchCustomEvent
 } from '../misc';
 
 describe('dom/events: misc', () => {
@@ -113,6 +114,47 @@ describe('dom/events: misc', () => {
         x:  (boundingClientRect.left + window.scrollX),
         y:  (boundingClientRect.top + window.scrollY)
       });
+    });
+  });
+
+  describe('dispatchCustomEvent works correctly', () => {
+    const el = document.createElement('div');
+    const mockDispatch = jest.spyOn(el, 'dispatchEvent');
+
+    beforeEach(() => mockDispatch.mockReset());
+
+    test('dispatchCustomEvent dispatches CustomEvent instance on the provided element', () => {
+      const eventName = `click${Math.random()}`;
+      const customEventInit = {detail: Math.random()};
+      dispatchCustomEvent(el, eventName, customEventInit);
+
+      expect(el.dispatchEvent).toHaveBeenCalled();
+
+      const event: CustomEvent = (el.dispatchEvent as jest.Mock).mock.calls[0][0];
+      expect(event.type).toBe(eventName);
+      expect(event.bubbles).toBe(true);
+      expect(event.cancelable).toBe(true);
+      expect((event as any).detail).toBe(customEventInit.detail);
+    });
+
+    test('dispatchCustomEvent dispatches CustomEvent instance with default params', () => {
+      const eventName = `click${Math.random()}`;
+      dispatchCustomEvent(el, eventName);
+
+      expect(el.dispatchEvent).toHaveBeenCalled();
+      const event: CustomEvent = (el.dispatchEvent as jest.Mock).mock.calls[0][0];
+      expect(event.bubbles).toBe(true);
+      expect(event.cancelable).toBe(true);
+    });
+
+    test('dispatchCustomEvent merge custom init before dispatching CustomEvent', () => {
+      const eventName = `click${Math.random()}`;
+      dispatchCustomEvent(el, eventName, {cancelable: false, bubbles: false});
+
+      expect(el.dispatchEvent).toHaveBeenCalled();
+      const event: CustomEvent = (el.dispatchEvent as jest.Mock).mock.calls[0][0];
+      expect(event.bubbles).toBe(false);
+      expect(event.cancelable).toBe(false);
     });
   });
 });

--- a/src/modules/esl-utils/dom/events/test/misc.test.ts
+++ b/src/modules/esl-utils/dom/events/test/misc.test.ts
@@ -5,8 +5,7 @@ import {
   isPassiveByDefault,
   getTouchPoint,
   getOffsetPoint,
-  getCompositeTarget,
-  splitEvents
+  getCompositeTarget
 } from '../misc';
 
 describe('dom/events: misc', () => {
@@ -115,36 +114,5 @@ describe('dom/events: misc', () => {
         y:  (boundingClientRect.top + window.scrollY)
       });
     });
-  });
-
-  describe('splitEvents', () => {
-    test(
-      'Empty string parsed to an empty array without exceptions',
-      () => expect(splitEvents('')).toEqual([])
-    );
-    test(
-      'Single event string parsed to single event',
-      () => expect(splitEvents('abc')).toEqual(['abc'])
-    );
-    test(
-      'Single event string with extra spaces parsed to single event',
-      () => expect(splitEvents('  abc ')).toEqual(['abc'])
-    );
-    test(
-      'Multiple events string parsed to separate events',
-      () => expect(splitEvents('abc de f')).toEqual(['abc', 'de', 'f'])
-    );
-    test(
-      'Multiple events string with extra spaces parsed to separate events',
-      () => expect(splitEvents(' a b')).toEqual(['a', 'b'])
-    );
-    test(
-      'The same events count ones when parsed (two unique terms)',
-      () => expect(splitEvents(' a a b')).toEqual(['a', 'b'])
-    );
-    test(
-      'The same events count ones when parsed (one unique term)',
-      () => expect(splitEvents('a a a a a')).toEqual(['a'])
-    );
   });
 });


### PR DESCRIPTION
- Move `splitEvents` to internal listener implementation
- Make `EventUtils.dispatch` alias for `dispatchCustomEvent` utility of esl-utils module 