### PR TITLE
chore: return back type-checking for tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,6 @@
 module.exports = {
   transform: {
-    '^.+\\.tsx?$': ['ts-jest', {
-      isolatedModules: true
-    }]
+    '^.+\\.tsx?$': ['ts-jest']
   },
   testEnvironment: 'jsdom',
   roots: ['src/modules', 'src/polyfills'],


### PR DESCRIPTION
Type checking returned as it needs to be performed while the full run of the unit tests.