### PR TITLE
feat(esl-tabs): `ESLTabs` migrated to `ESLEventListeners`

### DIFF
--- a/src/modules/esl-tab/core/esl-tabs.ts
+++ b/src/modules/esl-tab/core/esl-tabs.ts
@@ -198,6 +198,7 @@ export class ESLTabs extends ESLBaseElement {
   }
 
   @listen({
+    auto: false,
     event: 'scroll',
     target: (el: ESLTabs) => el.$scrollableTarget
   })


### PR DESCRIPTION
BREAKING-CHANGE: listeners extended from `ESLTabs` should now use `@listen` annotation to work correctly