### PR TITLE
feat(esl-event-listener): improve `ESLEventListener` object to have exact handler for simple subscriptions

### DIFF
--- a/src/modules/esl-base-element/test/element.listener.test.ts
+++ b/src/modules/esl-base-element/test/element.listener.test.ts
@@ -28,7 +28,7 @@ describe('ESLBaseElement: listeners', () => {
       mockHandler.mockReset();
       el.click();
       expect(mockHandler).toBeCalled();
-      expect(mockHandler).lastCalledWith(el, expect.any(Event), expect.any(Object));
+      expect(mockHandler).lastCalledWith(el, expect.any(Event));
     });
 
     test('ESLBaseElement successfully auto unsubscribed', async () => {

--- a/src/modules/esl-event-listener/core/listener.ts
+++ b/src/modules/esl-event-listener/core/listener.ts
@@ -91,7 +91,10 @@ export class ESLEventListener implements ESLListenerDefinition, EventListenerObj
     return false;
   }
 
-  /** Returns exact bound handler (used as callback for low-level subscriptions) */
+  /**
+   * Memoized builder for bound and decorated low level subscription.
+   * Implements DOM API {@link EventListenerObject.handleEvent}
+   */
   @memoize()
   public get handleEvent(): EventListener {
     const handlerBound = this.handler.bind(this.host);

--- a/src/modules/esl-event-listener/core/types.ts
+++ b/src/modules/esl-event-listener/core/types.ts
@@ -1,4 +1,3 @@
-import type {ESLEventListener} from './listener';
 import type {PropertyProvider} from '../../esl-utils/misc/functions';
 
 /** String CSS selector to find the target or {@link EventTarget} object or array of {@link EventTarget}s */
@@ -47,7 +46,7 @@ export interface ESLListenerDefinition<EType extends keyof ESLListenerEventMap =
 }
 
 /** Describes callback handler */
-export type ESLListenerHandler<EType extends Event = Event> = (event: EType, listener: ESLEventListener) => void;
+export type ESLListenerHandler<EType extends Event = Event> = (event: EType) => void;
 
 /** Condition (criteria) to find {@link ESLListenerDescriptor} */
 export type ESLListenerCriteria = undefined | keyof ESLListenerEventMap | ESLListenerHandler | Partial<ESLListenerDefinition>;

--- a/src/modules/esl-mixin-element/test/mixin.listener-herpers.test.ts
+++ b/src/modules/esl-mixin-element/test/mixin.listener-herpers.test.ts
@@ -1,5 +1,5 @@
 import {ESLMixinElement} from '../ui/esl-mixin-element';
-import {EventUtils} from '../../esl-event-listener/core/api';
+import {ESLEventUtils} from '../../esl-event-listener/core/api';
 
 describe('Shortcut helpers for EventUtils', () => {
   class TestHelpersMixin extends ESLMixinElement {
@@ -15,7 +15,7 @@ describe('Shortcut helpers for EventUtils', () => {
   afterAll(() => document.body.removeChild($el));
 
   test('$$on call leads to correct subscribe call with mixin as a host', () => {
-    const mock = jest.spyOn(EventUtils, 'subscribe');
+    const mock = jest.spyOn(ESLEventUtils, 'subscribe');
     const mixin = TestHelpersMixin.get($el) as TestHelpersMixin;
     const props = {event: 'test'};
     mixin.$$on(props, mixin.onEvent);
@@ -23,7 +23,7 @@ describe('Shortcut helpers for EventUtils', () => {
   });
 
   test('$$off call leads to correct unsubscribe call with mixin as a host', () => {
-    const mock = jest.spyOn(EventUtils, 'unsubscribe');
+    const mock = jest.spyOn(ESLEventUtils, 'unsubscribe');
     const mixin = TestHelpersMixin.get($el) as TestHelpersMixin;
     const props = {event: 'test'};
     mixin.$$off(props, mixin.onEvent);

--- a/src/modules/esl-mixin-element/test/mixin.listener.test.ts
+++ b/src/modules/esl-mixin-element/test/mixin.listener.test.ts
@@ -27,7 +27,7 @@ describe('ESLMixinElement: listeners', () => {
       mockHandler.mockReset();
       el.click();
       expect(mockHandler).toBeCalled();
-      expect(mockHandler).lastCalledWith(TestElement.get(el), expect.any(Event), expect.any(Object));
+      expect(mockHandler).lastCalledWith(TestElement.get(el), expect.any(Event));
     });
 
     test('ESLMixinElement successfully auto unsubscribed', async () => {


### PR DESCRIPTION
For purpose of improving debugging, now event subscription does not wrap handler function if there is no need (`once` marker or delegation (`selector`))
