### PR TITLE
Fix redirect for `/utils/esl-utils/`

### DIFF
--- a/pages/views/redirect/esl-utils.njk
+++ b/pages/views/redirect/esl-utils.njk
@@ -1,6 +1,6 @@
 ---
 layout: forward
-target: /core/
+target: /core/esl-utils/
 permalink: /utils/esl-utils/index.html
 eleventyExcludeFromCollections: true
 ---

--- a/pages/views/redirect/esl-utils.njk
+++ b/pages/views/redirect/esl-utils.njk
@@ -1,6 +1,6 @@
 ---
 layout: forward
 target: /core/
-permalink: /utils/index.html
+permalink: /utils/esl-utils/index.html
 eleventyExcludeFromCollections: true
 ---

--- a/pages/views/redirect/utils.njk
+++ b/pages/views/redirect/utils.njk
@@ -1,6 +1,6 @@
 ---
 layout: forward
 target: /core/
-permalink: /utils/index.html
+permalink: /utils/esl-utils/index.html
 eleventyExcludeFromCollections: true
 ---


### PR DESCRIPTION
The permalink for `/utils/esl-utils/` was added