### PR TITLE
style: use abilities of new this.constructor strict type

### DIFF
--- a/pages/src/landing/marquee/marquee.ts
+++ b/pages/src/landing/marquee/marquee.ts
@@ -7,6 +7,10 @@ export class ESLDemoMarquee extends ESLBaseElement {
   static override is = 'esl-d-marquee';
   static STARS_SEL = 'use';
 
+  // @see https://github.com/Microsoft/TypeScript/issues/3841#issuecomment-337560146
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  override ['constructor']!: typeof ESLDemoMarquee & Function;
+
   @attr({defaultValue: '4'}) public targetsNumber: string;
   @attr({defaultValue: '3000'}) public iterationTime: string;
 
@@ -26,7 +30,7 @@ export class ESLDemoMarquee extends ESLBaseElement {
 
   @memoize()
   public get $stars(): HTMLElement[] {
-    return Array.from(document.querySelectorAll((this.constructor as typeof ESLDemoMarquee).STARS_SEL));
+    return Array.from(document.querySelectorAll(this.constructor.STARS_SEL));
   }
   public get $randomStar(): HTMLElement {
     const index = Math.floor(Math.random() * this.$stars.length);

--- a/src/modules/draft/esl-carousel/plugin/esl-carousel-plugin.ts
+++ b/src/modules/draft/esl-carousel/plugin/esl-carousel-plugin.ts
@@ -14,11 +14,15 @@ export abstract class ESLCarouselPlugin extends ESLBaseElement {
    */
   public static freePlacement = false;
 
+  // @see https://github.com/Microsoft/TypeScript/issues/3841#issuecomment-337560146
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  override ['constructor']!: typeof ESLCarouselPlugin & Function;
+
   /**
    * @returns carousel owner of the plugin
    */
   protected findCarouselOwner(): ESLCarousel | null {
-    if ((this.constructor as typeof ESLCarouselPlugin).freePlacement) {
+    if (this.constructor.freePlacement) {
       return this.closest(ESLCarousel.is);
     } else {
       return this.parentNode as ESLCarousel;

--- a/src/modules/esl-a11y-group/core/esl-a11y-group.ts
+++ b/src/modules/esl-a11y-group/core/esl-a11y-group.ts
@@ -25,6 +25,10 @@ export class ESLA11yGroup extends ESLBaseElement {
     [ARROW_RIGHT]: 'next'
   };
 
+  // @see https://github.com/Microsoft/TypeScript/issues/3841#issuecomment-337560146
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  override ['constructor']!: typeof ESLA11yGroup & Function;
+
   /** Target elements multiple selector ({@link ESLTraversingQuery} syntax) */
   @attr({defaultValue: '::child'}) public targets: string;
 
@@ -51,7 +55,7 @@ export class ESLA11yGroup extends ESLBaseElement {
     const target = e.target as HTMLElement;
     if (!this.$targets.includes(target)) return;
 
-    const groupTarget = (this.constructor as typeof ESLA11yGroup).KEY_MAP[e.key];
+    const groupTarget = this.constructor.KEY_MAP[e.key];
     if (!groupTarget) return;
 
     this.goTo(groupTarget, target);

--- a/src/modules/esl-alert/core/esl-alert.ts
+++ b/src/modules/esl-alert/core/esl-alert.ts
@@ -37,6 +37,10 @@ export class ESLAlert extends ESLToggleable {
     hideDelay: 2500
   };
 
+  // @see https://github.com/Microsoft/TypeScript/issues/3841#issuecomment-337560146
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  override ['constructor']!: typeof ESLAlert & Function;
+
   /** Event to show alert component */
   @prop('esl:alert:show') public override SHOW_REQUEST_EVENT: string;
   /** Event to hide alert component */
@@ -70,8 +74,7 @@ export class ESLAlert extends ESLToggleable {
   }
 
   protected override mergeDefaultParams(params?: ESLToggleableActionParams): ESLToggleableActionParams {
-    const type = this.constructor as typeof ESLAlert;
-    return Object.assign({}, type.defaultConfig, this.defaultParams || {}, params || {});
+    return Object.assign({}, this.constructor.defaultConfig, this.defaultParams || {}, params || {});
   }
 
   protected override attributeChangedCallback(attrName: string, oldVal: string, newVal: string): void {

--- a/src/modules/esl-footnotes/core/esl-note.ts
+++ b/src/modules/esl-footnotes/core/esl-note.ts
@@ -22,6 +22,10 @@ export class ESLNote extends ESLBaseElement {
   /** Timeout before activating note (to have time to show content with this note) */
   public static readonly activateTimeout = 100;
 
+  // @see https://github.com/Microsoft/TypeScript/issues/3841#issuecomment-337560146
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  override ['constructor']!: typeof ESLNote & Function;
+
   /** Event to request acknowledgment from {@link ESLNotes} instances */
   @prop('esl:footnotes:request') public FOOTNOTE_REQUEST_EVENT: string;
   /** Event to acknowledge {@link ESLFootnotes} instance about footnote */
@@ -140,7 +144,7 @@ export class ESLNote extends ESLBaseElement {
     ESLEventUtils.dispatch(this, 'esl:show:request');
     // TODO: replace timeout with a more reliable mechanism to have time to show content with this note
     repeatSequence(() => {
-      return promisifyTimeout((this.constructor as typeof ESLNote).activateTimeout)
+      return promisifyTimeout(this.constructor.activateTimeout)
         .then(() => scrollIntoView(this, {behavior: 'smooth', block: 'center'}))
         .then(() => ESLTooltip.open || this.showTooltip());
     }, 3);

--- a/src/modules/esl-forms/esl-select-list/core/esl-select-wrapper.ts
+++ b/src/modules/esl-forms/esl-select-list/core/esl-select-wrapper.ts
@@ -49,6 +49,10 @@ export abstract class ESLSelectWrapper extends ESLBaseElement implements ESLSele
     characterData: true
   };
 
+  // @see https://github.com/Microsoft/TypeScript/issues/3841#issuecomment-337560146
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  override ['constructor']!: typeof ESLSelectWrapper & Function;
+
   private _$select: HTMLSelectElement;
   private _mutationObserver = new MutationObserver(this._onTargetMutation.bind(this));
 
@@ -83,8 +87,7 @@ export abstract class ESLSelectWrapper extends ESLBaseElement implements ESLSele
                             oldTarget: HTMLSelectElement | undefined): void {
     this.$$on(this._onChange);
     this._mutationObserver.disconnect();
-    const type = (this.constructor as typeof ESLSelectWrapper);
-    if (newTarget) this._mutationObserver.observe(newTarget, type.observationConfig);
+    if (newTarget) this._mutationObserver.observe(newTarget, this.constructor.observationConfig);
   }
 
   protected _onTargetMutation(changes: MutationRecord[]): void {

--- a/src/modules/esl-image/core/esl-image.ts
+++ b/src/modules/esl-image/core/esl-image.ts
@@ -27,6 +27,11 @@ export class ESLImage extends ESLBaseElement {
   /** Default container class value */
   public static DEFAULT_CONTAINER_CLS = 'img-container-loaded';
 
+  // @see https://github.com/Microsoft/TypeScript/issues/3841#issuecomment-337560146
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  override ['constructor']!: typeof ESLImage & Function;
+
+
   public static readonly STRATEGIES = STRATEGIES;
   public static readonly EMPTY_IMAGE = EMPTY_IMAGE;
 
@@ -296,7 +301,7 @@ export class ESLImage extends ESLBaseElement {
 
   public updateContainerClasses(): void {
     if (this.containerClass === null) return;
-    const cls = this.containerClass || (this.constructor as typeof ESLImage).DEFAULT_CONTAINER_CLS;
+    const cls = this.containerClass || this.constructor.DEFAULT_CONTAINER_CLS;
     const state = isLoadState(this.containerClassState) && this[this.containerClassState];
 
     const targetEl = ESLTraversingQuery.first(this.containerClassTarget, this) as HTMLElement;

--- a/src/modules/esl-media/core/esl-media-provider.ts
+++ b/src/modules/esl-media/core/esl-media-provider.ts
@@ -35,6 +35,10 @@ export type ProviderObservedParams = 'loop' | 'muted' | 'controls';
 export abstract class BaseProvider {
   static readonly providerName: string;
 
+  // @see https://github.com/Microsoft/TypeScript/issues/3841#issuecomment-337560146
+  // eslint-disable-next-line @typescript-eslint/ban-types
+ ['constructor']!: typeof BaseProvider & Function;
+
   static parseUrl(url: string): Partial<MediaProviderConfig> | null {
     return null;
   }
@@ -77,7 +81,7 @@ export abstract class BaseProvider {
 
   /** Provider name */
   public get name(): string {
-    return (this.constructor as typeof BaseProvider).providerName;
+    return this.constructor.providerName;
   }
 
   /** @returns current state of the player */

--- a/src/modules/esl-media/providers/brightcove-provider.ts
+++ b/src/modules/esl-media/providers/brightcove-provider.ts
@@ -37,6 +37,10 @@ export class BrightcoveProvider extends BaseProvider {
     };
   }
 
+  // @see https://github.com/Microsoft/TypeScript/issues/3841#issuecomment-337560146
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  override ['constructor']!: typeof BrightcoveProvider & Function;
+
   /** Loads player API according defined settings */
   protected static loadAPI(account: BCPlayerAccount): Promise<Event> {
     const apiSrc =
@@ -103,12 +107,11 @@ export class BrightcoveProvider extends BaseProvider {
   }
 
   public bind(): void {
-    const Provider = (this.constructor as typeof BrightcoveProvider);
-    this._account = Provider.getAccount(this.component);
+    this._account = this.constructor.getAccount(this.component);
     this._el = this.buildVideo();
     this.component.appendChild(this._el);
 
-    this._ready = Provider.loadAPI(this._account)
+    this._ready = this.constructor.loadAPI(this._account)
       .then(() => this.onAPILoaded())
       .then(() => this.onAPIReady())
       .catch((e) => this.component._onError(e));

--- a/src/modules/esl-toggleable/core/esl-toggleable-placeholder.ts
+++ b/src/modules/esl-toggleable/core/esl-toggleable-placeholder.ts
@@ -10,6 +10,10 @@ export class ESLToggleablePlaceholder extends ESLBaseElement {
   /** List of attributes allowed to copy from origin to this element */
   public static readonly allowedAttrs: string[] = ['id', 'class'];
 
+  // @see https://github.com/Microsoft/TypeScript/issues/3841#issuecomment-337560146
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  override ['constructor']!: typeof ESLToggleablePlaceholder & Function;
+
   public $origin: ESLToggleable | null;
 
   /** Сreates a placeholder for a given element of the toggleable's descendant */
@@ -34,7 +38,7 @@ export class ESLToggleablePlaceholder extends ESLBaseElement {
     const {$origin} = this;
     if (!$origin) return;
 
-    (this.constructor as typeof ESLToggleablePlaceholder).allowedAttrs.forEach((name) => {
+    this.constructor.allowedAttrs.forEach((name) => {
       const value = $origin.getAttribute(name);
       if (value) {
         this.setAttribute(this.buildAttrName(name), value);

--- a/src/modules/esl-utils/dom/events/target.ts
+++ b/src/modules/esl-utils/dom/events/target.ts
@@ -7,6 +7,10 @@ export class SyntheticEventTarget implements EventTarget {
   // Event type to use in the shortcutted calls
   public static DEFAULT_EVENT = 'change';
 
+  // @see https://github.com/Microsoft/TypeScript/issues/3841#issuecomment-337560146
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  ['constructor']!: typeof SyntheticEventTarget & Function;
+
   private readonly _listeners: Record<string, EventListenerOrEventListenerObject[]> = {};
 
   public hasEventListener(): boolean;
@@ -20,7 +24,7 @@ export class SyntheticEventTarget implements EventTarget {
   public addEventListener(callback: EventListenerOrEventListenerObject): void;
   public addEventListener(type: string, callback: EventListenerOrEventListenerObject): void;
   public addEventListener(type: string | EventListenerOrEventListenerObject, callback?: EventListenerOrEventListenerObject): void {
-    if (typeof type !== 'string') return this.addEventListener((this.constructor as typeof SyntheticEventTarget).DEFAULT_EVENT, type);
+    if (typeof type !== 'string') return this.addEventListener(this.constructor.DEFAULT_EVENT, type);
 
     validateEventListenerType(callback);
     if (this._listeners[type] && this._listeners[type].includes(callback!)) return;
@@ -31,7 +35,7 @@ export class SyntheticEventTarget implements EventTarget {
   public removeEventListener(callback: EventListenerOrEventListenerObject): void;
   public removeEventListener(type: string, callback: EventListenerOrEventListenerObject): void;
   public removeEventListener(type: string | EventListenerOrEventListenerObject, callback?: EventListenerOrEventListenerObject): void {
-    if (typeof type !== 'string') return this.removeEventListener((this.constructor as typeof SyntheticEventTarget).DEFAULT_EVENT, type);
+    if (typeof type !== 'string') return this.removeEventListener(this.constructor.DEFAULT_EVENT, type);
 
     validateEventListenerType(callback);
     if (!this._listeners[type]) return;


### PR DESCRIPTION
Description:

Get rid of casting ```this.constructor``` to access static variables

