### PR TITLE
fix(esl-event-listener): fix typechecking for TS5

### DIFF
--- a/src/modules/esl-event-listener/core/listener.ts
+++ b/src/modules/esl-event-listener/core/listener.ts
@@ -68,7 +68,7 @@ export class ESLEventListener implements ESLListenerDefinition, EventListenerObj
     const target = resolveProperty(this.target, this.host);
     if (isObject(target)) return wrap(target);
     const $host = '$host' in this.host ? this.host.$host : this.host;
-    if (typeof target === 'string') return ESLTraversingQuery.all(target, $host);
+    if (typeof target === 'string') return ESLTraversingQuery.all(target, $host as any);
     if (typeof target === 'undefined' && $host instanceof HTMLElement) return [$host];
     return [];
   }
@@ -153,8 +153,8 @@ export class ESLEventListener implements ESLListenerDefinition, EventListenerObj
   /** Adds listener to the listener store of the host object */
   protected static add(host: object, instance: ESLEventListener): void {
     if (!isObject(host)) return;
-    if (!Object.hasOwnProperty.call(host, LISTENERS)) host[LISTENERS] = [];
-    host[LISTENERS].push(instance);
+    if (!Object.hasOwnProperty.call(host, LISTENERS)) (host as any)[LISTENERS] = [];
+    (host as any)[LISTENERS].push(instance);
   }
   /** Removes listener from the listener store of the host object */
   protected static remove(host: object, instance: ESLEventListener): void {


### PR DESCRIPTION
- fix restrictions on the host passing to `TraversingQuery` (does not restrict host type due to availability of making absolute queries)
- remove the restriction of host key access due to partial typings of `Object.hasOwnProperty.call` instruction (will be removed with `Obgect.hasOwn` integration) 