### PR TITLE
fix(esl-utils): make ts decorators compatiable with babel

### DIFF
--- a/src/modules/esl-utils/decorators/attr.ts
+++ b/src/modules/esl-utils/decorators/attr.ts
@@ -33,7 +33,7 @@ const buildAttrName =
  * @param config - mapping configuration. See {@link AttrDescriptor}
  */
 export const attr = <T = string>(config: AttrDescriptor<T> = {}): ESLAttributeDecorator => {
-  return (target: ESLDomElementTarget, propName: string): void => {
+  return (target: ESLDomElementTarget, propName: string): any => {
     const attrName = buildAttrName(config.name || propName, !!config.dataAttr);
 
     function get(): T | null {
@@ -46,5 +46,6 @@ export const attr = <T = string>(config: AttrDescriptor<T> = {}): ESLAttributeDe
     }
 
     Object.defineProperty(target, propName, config.readonly ? {get} : {get, set});
+    return {};
   };
 };

--- a/src/modules/esl-utils/decorators/bool-attr.ts
+++ b/src/modules/esl-utils/decorators/bool-attr.ts
@@ -34,8 +34,9 @@ const buildAttrName =
  * @param config - mapping configuration. See {@link BoolAttrDescriptor}
  */
 export const boolAttr = (config: BoolAttrDescriptor = {}): ESLAttributeDecorator => {
-  return (target: ESLDomElementTarget, propName: string): void => {
+  return (target: ESLDomElementTarget, propName: string): any => {
     const attrName = buildAttrName(config.name || propName, !!config.dataAttr);
     Object.defineProperty(target, propName, buildConditionalDescriptor(attrName, !!config.readonly));
+    return {};
   };
 };

--- a/src/modules/esl-utils/decorators/json-attr.ts
+++ b/src/modules/esl-utils/decorators/json-attr.ts
@@ -44,8 +44,9 @@ const buildAttrName =
  */
 export const jsonAttr = <T>(config: JsonAttrDescriptor<T> = {}): ESLAttributeDecorator => {
   config = Object.assign({defaultValue: {}}, config);
-  return (target: ESLDomElementTarget, propName: string): void => {
+  return (target: ESLDomElementTarget, propName: string): any => {
     const attrName = buildAttrName(config.name || propName, !!config.dataAttr);
     Object.defineProperty(target, propName, buildJsonAttrDescriptor(attrName, !!config.readonly, config.defaultValue));
+    return {};
   };
 };

--- a/src/modules/esl-utils/decorators/prop.ts
+++ b/src/modules/esl-utils/decorators/prop.ts
@@ -20,7 +20,7 @@ export type OverrideDecoratorConfig = {
  * @param prototypeConfig - prototype property configuration
  */
 export function prop(value?: any, prototypeConfig: OverrideDecoratorConfig = {}) {
-  return function (obj: any, name: string): void {
+  return function (obj: any, name: string): any {
     if (Object.hasOwnProperty.call(obj, name)) {
       throw new TypeError('Can\'t override own property');
     }
@@ -30,5 +30,6 @@ export function prop(value?: any, prototypeConfig: OverrideDecoratorConfig = {})
       enumerable:  !prototypeConfig.enumerable,
       configurable: true
     });
+    return {};
   };
 }


### PR DESCRIPTION
Upon implementation of showcase repository of JavaScript project that uses ESL (https://github.com/fshovchko/esl-decorators-test), it was discovered that some of our decorators do not work with babel. The most problematic ones were property decorators. For some reason, instance always had value set to 'undefined', and the prototype had the correct value. But because instance had 'undefined' value, the prototype value was always ignored.
It was discovered, the legacy decorators in Babel behave different than legacy decorators in TypeScript (https://github.com/babel/babel/issues/8864). For example:
- In Babel legacy decorators, they may receive an initializer property instead of a value property, but in TypeScript there is never an initializer property, only a value property.
- In TypeScript, decorators must return a descriptor for them to be chained with other decorators on the same class element.
- In TypeScript, the previous point (decorator returning a descriptor) results in the class field (if decorator was used on a field) having [[Set]] semantics when useDefineForClassFields is set to false (otherwise many decorators would break).
- In Babel, if a legacy decorator returns a descriptor, this causes the class field to always use [[Define]] semantics, regardless of the value of the loose option for the plugin-proposal-class-properties option, which is opposite of TypeScript behavior.
- In TypeScript property decorators don't receive a descriptor, but they do in Babel.

It was an attempt to make our descriptor implementation to return the decorator target. It seemed to work, but made almost everything break for typescript transpiler.

Solution was found to return the dummy descriptor(empty object), which seems to work both in ts and babel (https://github.com/mikro-orm/mikro-orm/issues/840).