### PR TITLE
fix(esl-togglable): open attribute change behavior

### DIFF
--- a/src/modules/esl-toggleable/core/esl-toggleable-dispatcher.ts
+++ b/src/modules/esl-toggleable/core/esl-toggleable-dispatcher.ts
@@ -18,7 +18,7 @@ export class ESLToggleableDispatcher extends ESLBaseElement {
    * Uses esl-toggleable-dispatcher tag and document body root by default
    */
   public static init(root: HTMLElement = document.body, tagName: string = this.is): void {
-    if (!root) throw new Error('Root element should be specified');
+    if (!root) throw new Error('[ESL]: Root element should be specified');
     const instances = root.getElementsByTagName(tagName);
     if (instances.length) return;
     this.register(tagName);

--- a/src/modules/esl-toggleable/core/esl-toggleable.ts
+++ b/src/modules/esl-toggleable/core/esl-toggleable.ts
@@ -148,12 +148,12 @@ export class ESLToggleable extends ESLBaseElement {
   protected override attributeChangedCallback(attrName: string, oldVal: string, newVal: string): void {
     if (!this.connected || newVal === oldVal) return;
     switch (attrName) {
-      case 'open':
-        // eslint-disable-next-line no-case-declarations
+      case 'open': {
         const isOpen = this.hasAttribute('open');
         if (this.open === isOpen) return;
         this.toggle(isOpen, {initiator: 'attribute', showDelay: 0, hideDelay: 0});
         break;
+      }
       case 'group':
         this.$$fire(this.GROUP_CHANGED_EVENT, {
           detail: {oldGroupName: oldVal, newGroupName: newVal}

--- a/src/modules/esl-toggleable/core/esl-toggleable.ts
+++ b/src/modules/esl-toggleable/core/esl-toggleable.ts
@@ -149,8 +149,10 @@ export class ESLToggleable extends ESLBaseElement {
     if (!this.connected || newVal === oldVal) return;
     switch (attrName) {
       case 'open':
-        if (this.open === this.hasAttribute('open')) return;
-        this.toggle(this.open, {initiator: 'attribute', showDelay: 0, hideDelay: 0});
+        // eslint-disable-next-line no-case-declarations
+        const isOpen = this.hasAttribute('open');
+        if (this.open === isOpen) return;
+        this.toggle(isOpen, {initiator: 'attribute', showDelay: 0, hideDelay: 0});
         break;
       case 'group':
         this.$$fire(this.GROUP_CHANGED_EVENT, {


### PR DESCRIPTION
The scope of this PR is to resolve issue described in #1799 + updated error message for toggleable dispatcher. ESLint didn't like the extra declaration, so another way of fixing it may be:
```
    if (!this.connected || newVal === oldVal) return;
    const isOpen = this.hasAttribute('open');
    switch (attrName) {
      case 'open':
        if (this.open === isOpen) return;
        this.toggle(isOpen, {initiator: 'attribute', showDelay: 0, hideDelay: 0});
        break;
```