### PR TITLE
feat(swipe-target): Add SwipeEventTarget

### DIFF
--- a/src/modules/esl-event-listener/README.md
+++ b/src/modules/esl-event-listener/README.md
@@ -572,6 +572,43 @@ ESLEventUtils.subscribe(host, {
 }, onResize);
 ```
 
+<a name="-esleventutilswipe"></a>
+
+### ⚡ `ESLSwipeEventTarget.for`
+
+`ESLSwipeEventTarget.for` is a simple and easy-to-use way to listen for swipe events on any element.
+
+`ESLSwipeEventTarget.for` creates a synthetic target and subscribes it to `swipe` events. It detects `pointerdown` and 
+`pointerup` events and based on the distance (`threshold`) between start and end points and time (`timeout`) between 
+`pointerdown` and `pointerup` events, triggers `swipe`, `swipe:left`, `swipe:right`, `swipe:up`, and `swipe:down` 
+events on target element.
+
+```typescript
+ESLSwipeEventTarget.for(el: Element, threshold?: string, timeout?: number): ESLSwipeEventTarget;
+```
+
+**Parameters**:
+
+- `el` - `Element` The element to listen for swipe events on.
+- `threshold` - `string` - The distance threshold (px, vh, vw supported) that must be traveled before a swipe 
+event is triggered. Defaults to 20px.
+- `timeout` - `number` - The time in milliseconds that must elapse between pointerdown and pointerup events before a 
+swipe event is triggered. Defaults to 500.
+
+Usage example:
+
+```typescript
+ESLEventUtils.subscribe(host, {
+  event: 'swipe',
+  target: ESLSwipeEventTarget.for(el)
+}, onSwipe);
+// or
+ESLSwipeEventTarget.subscribe(host, {
+  event: 'swipe:left',
+  target: (host) => ESLSwipeEventTarget.for(host.el, '30px', 1000)
+}, onSwipe);
+```
+
 ---
 
 ## <a name="embedded-behavior-of-eslbaseelement-eslmixinelement">Embedded behavior of `ESLBaseElement` / `ESLMixinElement`</a>

--- a/src/modules/esl-event-listener/README.md
+++ b/src/modules/esl-event-listener/README.md
@@ -578,7 +578,7 @@ ESLEventUtils.subscribe(host, {
 
 `ESLSwipeEventTarget.for` is a simple and easy-to-use way to listen for swipe events on any element.
 
-`ESLSwipeEventTarget.for` creates a synthetic target and subscribes it to `swipe` events. It detects `pointerdown` and 
+`ESLSwipeEventTarget.for` creates a synthetic target that produces `swipe` events. It detects `pointerdown` and 
 `pointerup` events and based on the distance (`threshold`) between start and end points and time (`timeout`) between 
 `pointerdown` and `pointerup` events, triggers `swipe`, `swipe:left`, `swipe:right`, `swipe:up`, and `swipe:down` 
 events on target element.

--- a/src/modules/esl-event-listener/README.md
+++ b/src/modules/esl-event-listener/README.md
@@ -574,38 +574,38 @@ ESLEventUtils.subscribe(host, {
 
 <a name="-esleventutilswipe"></a>
 
-### ⚡ `ESLSwipeEventTarget.for`
+### ⚡ `ESLSwipeGestureTarget.for`
 
-`ESLSwipeEventTarget.for` is a simple and easy-to-use way to listen for swipe events on any element.
+`ESLSwipeGestureTarget.for` is a simple and easy-to-use way to listen for swipe events on any element.
 
-`ESLSwipeEventTarget.for` creates a synthetic target that produces `swipe` events. It detects `pointerdown` and 
+`ESLSwipeGestureTarget.for` creates a synthetic target that produces `swipe` events. It detects `pointerdown` and 
 `pointerup` events and based on the distance (`threshold`) between start and end points and time (`timeout`) between 
 `pointerdown` and `pointerup` events, triggers `swipe`, `swipe:left`, `swipe:right`, `swipe:up`, and `swipe:down` 
 events on target element.
 
 ```typescript
-ESLSwipeEventTarget.for(el: Element, threshold?: string, timeout?: number): ESLSwipeEventTarget;
+ESLSwipeGestureTarget.for(el: Element, settings?: ESLSwipeGestureSetting): ESLSwipeGestureTarget;
 ```
 
 **Parameters**:
 
 - `el` - `Element` The element to listen for swipe events on.
-- `threshold` - `string` - The distance threshold (px, vh, vw supported) that must be traveled before a swipe 
-event is triggered. Defaults to 20px.
-- `timeout` - `number` - The time in milliseconds that must elapse between pointerdown and pointerup events before a 
-swipe event is triggered. Defaults to 500.
+- `settings` - optional settings (`ESLSwipeGestureSetting`)
 
 Usage example:
 
 ```typescript
 ESLEventUtils.subscribe(host, {
   event: 'swipe',
-  target: ESLSwipeEventTarget.for(el)
+  target: ESLSwipeGestureTarget.for(el)
 }, onSwipe);
 // or
-ESLSwipeEventTarget.subscribe(host, {
+ESLSwipeGestureTarget.subscribe(host, {
   event: 'swipe:left',
-  target: (host) => ESLSwipeEventTarget.for(host.el, '30px', 1000)
+  target: (host) => ESLSwipeGestureTarget.for(host.el, {
+    threshold: '30px',
+    timeout: 1000
+  })
 }, onSwipe);
 ```
 

--- a/src/modules/esl-event-listener/core/targets/swipe.event.ts
+++ b/src/modules/esl-event-listener/core/targets/swipe.event.ts
@@ -19,7 +19,7 @@ export interface ESLSwipeGestureEventInfo {
   direction: SwipeDirection;
   /** Distance between the points where pointerdown and pointerup events occurred along the x axis */
   distanceX: number;
-  /** Distance between the points where pointerdown and pointerup events occurred along the x axis */
+  /** Distance between the points where pointerdown and pointerup events occurred along the y axis */
   distanceY: number;
   /** Original pointerdown event */
   startEvent: PointerEvent;

--- a/src/modules/esl-event-listener/core/targets/swipe.event.ts
+++ b/src/modules/esl-event-listener/core/targets/swipe.event.ts
@@ -1,0 +1,47 @@
+import {overrideEvent} from '../../../esl-utils/dom/events/misc';
+
+/**
+ * Swipe directions that could be provided in {@link ESLSwipeGestureEvent}
+ */
+export type SwipeDirection = 'left' | 'right' | 'up' | 'down';
+
+/**
+ * Event names that could be triggered by {@link ESLSwipeGestureTarget}
+ */
+export type SwipeEventName = 'swipe' | 'swipe:left' | 'swipe:right' | 'swipe:up' | 'swipe:down';
+
+/**
+ * Describes swipe information provided with {@link ESLSwipeGestureEvent}
+ */
+export interface ESLSwipeGestureEventInfo {
+  target: Element;
+  /** Swipe direction {@link SwipeDirection} */
+  direction: SwipeDirection;
+  /** Distance between the points where pointerdown and pointerup events occurred along the x axis */
+  distanceX: number;
+  /** Distance between the points where pointerdown and pointerup events occurred along the x axis */
+  distanceY: number;
+  /** Original pointerdown event */
+  startEvent: PointerEvent;
+  /** Original pointerup event */
+  endEvent: PointerEvent;
+}
+
+/**
+ * Creates swipe event dispatched by {@link ESLSwipeGestureTarget}
+ */
+export class ESLSwipeGestureEvent extends UIEvent {
+  public override readonly target: Element;
+  public swipeInfo: ESLSwipeGestureEventInfo;
+
+  protected constructor(eventName: SwipeEventName, swipeInfo: ESLSwipeGestureEventInfo) {
+    super(eventName, {bubbles: true, cancelable: true});
+    this.swipeInfo = swipeInfo;
+    overrideEvent(this, 'target', swipeInfo.target);
+  }
+
+  /** Creates {@link ESLSwipeGestureEvent} from {@link ESLSwipeGestureTarget} */
+  public static fromConfig(eventName: SwipeEventName, swipeInfo: ESLSwipeGestureEventInfo): ESLSwipeGestureEvent {
+    return new ESLSwipeGestureEvent(eventName, swipeInfo);
+  }
+}

--- a/src/modules/esl-event-listener/core/targets/swipe.target.ts
+++ b/src/modules/esl-event-listener/core/targets/swipe.target.ts
@@ -26,15 +26,19 @@ export interface ESLSwipeGestureSetting {
   timeout?: number;
 }
 
+/**
+ * Synthetic target class that produces swipe events
+ */
 export class ESLSwipeGestureTarget extends SyntheticEventTarget {
-  protected startEl: HTMLElement | null;
-  protected startEvent: PointerEvent;
-  protected config: SwipeEventTargetConfig;
-  protected target: Element;
   protected static defaultConfig: SwipeEventTargetConfig = {
     threshold: '20px',
     timeout: 500
   };
+
+  protected startEvent: PointerEvent;
+  protected config: SwipeEventTargetConfig;
+  protected target: Element;
+  protected isGestureStarted: boolean = false;
 
   protected constructor(target: ESLDomElementTarget, settings: ESLSwipeGestureSetting) {
     super();
@@ -59,8 +63,8 @@ export class ESLSwipeGestureTarget extends SyntheticEventTarget {
    */
   @bind
   protected handleStart(e: PointerEvent): void {
-    this.startEl = e.target as HTMLElement;
     this.startEvent = e;
+    this.isGestureStarted = true;
   }
 
   /**
@@ -71,7 +75,7 @@ export class ESLSwipeGestureTarget extends SyntheticEventTarget {
   @bind
   protected handleEnd(e: PointerEvent): void {
     // if the user released on a different target, cancel!
-    if (this.startEl !== e.target) return;
+    if (!this.isGestureStarted || (this.startEvent?.target !== e.target)) return;
     const direction = this.resolveDirection(e);
 
     if (direction) {
@@ -90,8 +94,8 @@ export class ESLSwipeGestureTarget extends SyntheticEventTarget {
       this.dispatchEvent(ESLSwipeGestureEvent.fromConfig(`swipe:${direction}` as SwipeEventName, swipeInfo));
     }
 
-    // reset values
-    this.startEl = null;
+    // Mark swipe as completed
+    this.isGestureStarted = false;
   }
 
   /**

--- a/src/modules/esl-event-listener/core/targets/swipe.target.ts
+++ b/src/modules/esl-event-listener/core/targets/swipe.target.ts
@@ -7,9 +7,19 @@ import {ESLEventUtils} from '../api';
 
 import type {ESLDomElementTarget} from '../../../esl-utils/abstract/dom-target';
 
+/**
+ * Swipe directions that could be provided in {@link ESLSwipeGestureEvent}
+ */
 type SwipeDirection = 'left' | 'right' | 'up' | 'down';
+
+/**
+ * Event names that could be triggered by {@link ESLSwipeGestureTarget}
+ */
 type SwipeEventName = 'swipe' | 'swipe:left' | 'swipe:right' | 'swipe:up' | 'swipe:down';
 
+/**
+ * Describes event that could be triggered by {@link ESLSwipeGestureTarget}
+ */
 interface ESLSwipeGestureEvent {
   direction: SwipeDirection;
   distanceX: number;
@@ -18,12 +28,18 @@ interface ESLSwipeGestureEvent {
   endEvent: PointerEvent;
 }
 
+/**
+ * Describes parsed configuration of {@link ESLSwipeGestureTarget}
+ */
 interface SwipeEventTargetConfig {
   threshold: number;
   units: string;
   timeout: number;
 }
 
+/**
+ * Describes settings object that could be passed to {@link ESLSwipeGestureTarget.for} as optional parameter
+ */
 export interface ESLSwipeGestureSetting {
   threshold?: string;
   timeout?: number;
@@ -62,7 +78,7 @@ export class ESLSwipeGestureTarget extends SyntheticEventTarget {
   /**
    * Passes threshold into number and units, creates config from passed threshold and distance values or uses default ones.
    * @param settings - configuration options {@link ESLSwipeGestureSetting}
-   * @returns ESLSwipeEventTarget configuration {@link SwipeEventTargetConfig}.
+   * @returns ESLSwipeGestureTarget configuration {@link SwipeEventTargetConfig}.
    */
   protected getConfig(settings: ESLSwipeGestureSetting): SwipeEventTargetConfig {
     const config = ESLSwipeGestureTarget.defaultConfig;
@@ -77,7 +93,7 @@ export class ESLSwipeGestureTarget extends SyntheticEventTarget {
   /**
    * @param $target - a target element to observe pointer events to detect a gesture
    * @param settings - optional config override (will be merged with a default one if passed) {@link ESLSwipeGestureSetting}.
-   * @returns Returns the instance of ESLSwipeEventTarget {@link ESLSwipeGestureTarget}.
+   * @returns Returns the instance of ESLSwipeGestureTarget {@link ESLSwipeGestureTarget}.
    */
   public static for($target: ESLDomElementTarget, settings?: ESLSwipeGestureSetting): ESLSwipeGestureTarget {
     if ($target instanceof ESLMixinElement) return ESLSwipeGestureTarget.for($target.$host, settings);

--- a/src/modules/esl-event-listener/core/targets/swipe.target.ts
+++ b/src/modules/esl-event-listener/core/targets/swipe.target.ts
@@ -1,32 +1,12 @@
 import {SyntheticEventTarget} from '../../../esl-utils/dom/events/target';
 import {ESLMixinElement} from '../../../esl-mixin-element/ui/esl-mixin-element';
-import {overrideEvent} from '../../../esl-utils/dom/events/misc';
 import {resolveDomTarget} from '../../../esl-utils/abstract/dom-target';
 import {bind} from '../../../esl-utils/decorators/bind';
 import {ESLEventUtils} from '../api';
+import {ESLSwipeGestureEvent} from './swipe.event';
 
+import type {SwipeDirection, ESLSwipeGestureEventInfo, SwipeEventName} from './swipe.event';
 import type {ESLDomElementTarget} from '../../../esl-utils/abstract/dom-target';
-
-/**
- * Swipe directions that could be provided in {@link ESLSwipeGestureEvent}
- */
-type SwipeDirection = 'left' | 'right' | 'up' | 'down';
-
-/**
- * Event names that could be triggered by {@link ESLSwipeGestureTarget}
- */
-type SwipeEventName = 'swipe' | 'swipe:left' | 'swipe:right' | 'swipe:up' | 'swipe:down';
-
-/**
- * Describes event that could be triggered by {@link ESLSwipeGestureTarget}
- */
-interface ESLSwipeGestureEvent {
-  direction: SwipeDirection;
-  distanceX: number;
-  distanceY: number;
-  startEvent: PointerEvent;
-  endEvent: PointerEvent;
-}
 
 /**
  * Describes parsed configuration of {@link ESLSwipeGestureTarget}
@@ -126,7 +106,8 @@ export class ESLSwipeGestureTarget extends SyntheticEventTarget {
     const direction = this.resolveDirection(e);
 
     if (direction) {
-      const eventDetail: ESLSwipeGestureEvent = {
+      const swipeInfo: ESLSwipeGestureEventInfo = {
+        target: this.target,
         direction,
         distanceX: Math.abs(this.xDown - e.clientX),
         distanceY: Math.abs(this.yDown - e.clientY),
@@ -134,13 +115,10 @@ export class ESLSwipeGestureTarget extends SyntheticEventTarget {
         endEvent: e
       };
 
-      // fire `swiped` event on the element that started the swipe
-      const event = new CustomEvent('swipe', {bubbles: true, cancelable: true, detail: eventDetail});
-      this.dispatchEvent(overrideEvent(event, 'target', this.target));
-
-      // fire `swiped:${dir}` event on the element that started the swipe
-      const dirEvent = new CustomEvent(`swipe:${direction}`, {bubbles: true, cancelable: true, detail: eventDetail});
-      this.dispatchEvent(overrideEvent(dirEvent, 'target', this.target));
+      // fire `swipe` event on the element that started the swipe
+      this.dispatchEvent(ESLSwipeGestureEvent.fromConfig('swipe', swipeInfo));
+      // fire `swipe:${dir}` event on the element that started the swipe
+      this.dispatchEvent(ESLSwipeGestureEvent.fromConfig(`swipe:${direction}` as SwipeEventName, swipeInfo));
     }
 
     // reset values

--- a/src/modules/esl-event-listener/core/targets/swipe.target.ts
+++ b/src/modules/esl-event-listener/core/targets/swipe.target.ts
@@ -1,0 +1,149 @@
+import {SyntheticEventTarget} from '../../../esl-utils/dom/events/target';
+import {ESLMixinElement} from '../../../esl-mixin-element/ui/esl-mixin-element';
+import {overrideEvent} from '../../../esl-utils/dom/events/misc';
+
+type SwipeDirection = 'left' | 'right' | 'up' | 'down';
+type SwipeEventName = 'swipe' | 'swipe:left' | 'swipe:right' | 'swipe:up' | 'swipe:down';
+
+interface SwipeEvent {
+  direction: SwipeDirection;
+  distanceX: number;
+  distanceY: number;
+  touchStartOriginalEvent: PointerEvent;
+  touchEndOriginalEvent: PointerEvent;
+}
+
+interface SwipeEventTargetConfig {
+  threshold: number;
+  units: string;
+  timeout: number;
+}
+
+export class SwipeEventTarget extends SyntheticEventTarget {
+  protected xDown: number | null;
+  protected yDown: number | null;
+  protected timeDown: number | null;
+  protected startEl: HTMLElement | null;
+  protected startEvent: PointerEvent;
+  protected config: SwipeEventTargetConfig;
+  protected static unitsAvailable = ['vw', 'vh', 'px'];
+  protected static defaultConfig: SwipeEventTargetConfig = {
+    threshold: 20,
+    units: 'px',
+    timeout: 500
+  };
+
+  protected constructor(public readonly target: HTMLElement, threshold?: string, timeout?: number) {
+    super();
+    this.config = this.getConfig(threshold, timeout);
+  }
+
+  protected getConfig(threshold?: string, timeout?: number): SwipeEventTargetConfig {
+    const config = SwipeEventTarget.defaultConfig;
+
+    if (threshold) {
+      SwipeEventTarget.unitsAvailable.forEach((unit: string) => {
+        if (threshold.indexOf(unit) > 0) {
+          config.units = unit;
+          config.threshold = parseInt(threshold.replace(unit, ''), 10) || SwipeEventTarget.defaultConfig.threshold;
+        }
+      });
+    }
+
+    config.timeout = timeout || config.timeout;
+
+    return config;
+  }
+
+  public static for($el: HTMLElement | ESLMixinElement, threshold?: string, timeout?: number): SwipeEventTarget {
+    if ($el instanceof ESLMixinElement) return SwipeEventTarget.for($el.$host, threshold, timeout);
+
+    return new SwipeEventTarget($el, threshold, timeout);
+  }
+
+  public override addEventListener(callback: EventListener): void;
+  public override addEventListener(event: SwipeEventName, callback: EventListener): void;
+  public override addEventListener(event: any, callback: EventListener = event): void {
+    super.addEventListener(event, callback);
+    if (this.getEventListeners().length > 1) return;
+
+    this.target.addEventListener('pointerdown', this.handleStart.bind(this), false);
+    this.target.addEventListener('pointerup', this.handleEnd.bind(this), false);
+  }
+
+  protected handleStart(e: PointerEvent): void {
+    this.startEl = e.target as HTMLElement;
+    this.timeDown = e.timeStamp;
+    this.startEvent = e;
+    this.xDown = e.clientX;
+    this.yDown = e.clientY;
+  }
+
+  protected handleEnd(e: PointerEvent): void {
+    // if the user released on a different target, cancel!
+    if (this.startEl !== e.target) return;
+    const direction = this.resolveDirection(e);
+
+    if (direction) {
+      const eventDetail: SwipeEvent = {
+        direction,
+        distanceX: Math.abs(this.xDown - e.clientX),
+        distanceY: Math.abs(this.yDown - e.clientY),
+        touchStartOriginalEvent: this.startEvent,
+        touchEndOriginalEvent: e
+      };
+
+      // fire `swiped` event on the element that started the swipe
+      const event = new CustomEvent('swipe', {bubbles: true, cancelable: true, detail: eventDetail});
+      this.dispatchEvent(overrideEvent(event, 'target', this.target));
+
+      // fire `swiped:${dir}` event on the element that started the swipe
+      const dirEvent = new CustomEvent(`swipe:${direction}`, {bubbles: true, cancelable: true, detail: eventDetail});
+      this.dispatchEvent(overrideEvent(dirEvent, 'target', this.target));
+    }
+
+    // reset values
+    this.xDown = null;
+    this.yDown = null;
+    this.timeDown = null;
+    this.startEl = null;
+  }
+
+  protected resolveSwipeThreshold(): number {
+    let swipeThreshold = this.config.threshold;
+
+    if (this.config.units === 'vh') {
+      swipeThreshold = Math.round((swipeThreshold / 100) * document.documentElement.clientHeight); // get percentage of viewport height in pixels
+    }
+    if (this.config.units === 'vw') {
+      swipeThreshold = Math.round((swipeThreshold / 100) * document.documentElement.clientWidth); // get percentage of viewport width in pixels
+    }
+
+    return swipeThreshold;
+  }
+
+  protected resolveDirection(e: PointerEvent): SwipeDirection {
+    const xDiff = this.xDown - e.clientX;
+    const yDiff = this.yDown - e.clientY;
+    const swipeThreshold = this.resolveSwipeThreshold();
+    const timeDiff = e.timeStamp - this.timeDown;
+
+    if (Math.abs(xDiff) > Math.abs(yDiff) && Math.abs(xDiff) > swipeThreshold && timeDiff < this.config.timeout) {
+      return xDiff > 0 ? 'left' : 'right';
+    }
+    if (Math.abs(yDiff) > swipeThreshold && timeDiff < this.config.timeout) {
+      return yDiff > 0 ? 'up' : 'down';
+    }
+  }
+
+  /** Unsubscribes from the observed target {@link Element} changes */
+  public override removeEventListener(callback: EventListener): void;
+  public override removeEventListener(event: SwipeEventName, callback: EventListener): void;
+  public override removeEventListener(event: any, callback: EventListener = event): void {
+    super.removeEventListener(event, callback);
+    if (this.getEventListeners().length > 0) return;
+
+    this.target.removeEventListener('pointerdown', this.handleStart.bind(this), false);
+    this.target.removeEventListener('pointerup', this.handleEnd.bind(this), false);
+  }
+}

--- a/src/modules/esl-event-listener/core/targets/swipe.target.ts
+++ b/src/modules/esl-event-listener/core/targets/swipe.target.ts
@@ -26,9 +26,6 @@ export interface ESLSwipeGestureSetting {
 }
 
 export class ESLSwipeGestureTarget extends SyntheticEventTarget {
-  protected xDown: number;
-  protected yDown: number;
-  protected timeDown: number;
   protected startEl: HTMLElement | null;
   protected startEvent: PointerEvent;
   protected config: SwipeEventTargetConfig;
@@ -88,10 +85,7 @@ export class ESLSwipeGestureTarget extends SyntheticEventTarget {
   @bind
   protected handleStart(e: PointerEvent): void {
     this.startEl = e.target as HTMLElement;
-    this.timeDown = e.timeStamp;
     this.startEvent = e;
-    this.xDown = e.clientX;
-    this.yDown = e.clientY;
   }
 
   /**
@@ -109,8 +103,8 @@ export class ESLSwipeGestureTarget extends SyntheticEventTarget {
       const swipeInfo: ESLSwipeGestureEventInfo = {
         target: this.target,
         direction,
-        distanceX: Math.abs(this.xDown - e.clientX),
-        distanceY: Math.abs(this.yDown - e.clientY),
+        distanceX: Math.abs(this.startEvent.clientX - e.clientX),
+        distanceY: Math.abs(this.startEvent.clientY - e.clientY),
         startEvent: this.startEvent,
         endEvent: e
       };
@@ -147,10 +141,10 @@ export class ESLSwipeGestureTarget extends SyntheticEventTarget {
    * @returns direction of swipe {@link SwipeDirection}
    */
   protected resolveDirection(e: PointerEvent): SwipeDirection | null {
-    const xDiff = this.xDown - e.clientX;
-    const yDiff = this.yDown - e.clientY;
+    const xDiff = this.startEvent.clientX - e.clientX;
+    const yDiff = this.startEvent.clientY - e.clientY;
     const swipeThreshold = this.resolveSwipeThreshold();
-    const timeDiff = e.timeStamp - this.timeDown;
+    const timeDiff = e.timeStamp - this.startEvent.timeStamp;
 
     if (Math.abs(xDiff) > Math.abs(yDiff) && Math.abs(xDiff) > swipeThreshold && timeDiff < this.config.timeout) {
       return xDiff > 0 ? 'left' : 'right';
@@ -187,8 +181,5 @@ export class ESLSwipeGestureTarget extends SyntheticEventTarget {
 
     ESLEventUtils.unsubscribe(this.target, 'pointerdown');
     ESLEventUtils.unsubscribe(this.target, 'pointerup');
-
-    this.target.removeEventListener('pointerdown', this.handleStart.bind(this), false);
-    this.target.removeEventListener('pointerup', this.handleEnd.bind(this), false);
   }
 }

--- a/src/modules/esl-event-listener/core/targets/swipe.target.ts
+++ b/src/modules/esl-event-listener/core/targets/swipe.target.ts
@@ -19,7 +19,7 @@ interface SwipeEventTargetConfig {
   timeout: number;
 }
 
-export class SwipeEventTarget extends SyntheticEventTarget {
+export class ESLSwipeEventTarget extends SyntheticEventTarget {
   protected xDown: number;
   protected yDown: number;
   protected timeDown: number;
@@ -39,13 +39,13 @@ export class SwipeEventTarget extends SyntheticEventTarget {
   }
 
   protected getConfig(threshold?: string, timeout?: number): SwipeEventTargetConfig {
-    const config = SwipeEventTarget.defaultConfig;
+    const config = ESLSwipeEventTarget.defaultConfig;
 
     if (threshold) {
-      SwipeEventTarget.unitsAvailable.forEach((unit: string) => {
+      ESLSwipeEventTarget.unitsAvailable.forEach((unit: string) => {
         if (threshold.indexOf(unit) > 0) {
           config.units = unit;
-          config.threshold = parseInt(threshold.replace(unit, ''), 10) || SwipeEventTarget.defaultConfig.threshold;
+          config.threshold = parseInt(threshold.replace(unit, ''), 10) || ESLSwipeEventTarget.defaultConfig.threshold;
         }
       });
     }
@@ -55,10 +55,10 @@ export class SwipeEventTarget extends SyntheticEventTarget {
     return config;
   }
 
-  public static for($el: HTMLElement | ESLMixinElement, threshold?: string, timeout?: number): SwipeEventTarget {
-    if ($el instanceof ESLMixinElement) return SwipeEventTarget.for($el.$host, threshold, timeout);
+  public static for($el: HTMLElement | ESLMixinElement, threshold?: string, timeout?: number): ESLSwipeEventTarget {
+    if ($el instanceof ESLMixinElement) return ESLSwipeEventTarget.for($el.$host, threshold, timeout);
 
-    return new SwipeEventTarget($el, threshold, timeout);
+    return new ESLSwipeEventTarget($el, threshold, timeout);
   }
 
   public override addEventListener(callback: EventListener): void;

--- a/src/modules/esl-event-listener/core/targets/swipe.target.ts
+++ b/src/modules/esl-event-listener/core/targets/swipe.target.ts
@@ -148,8 +148,9 @@ export class ESLSwipeGestureTarget extends SyntheticEventTarget {
     super.addEventListener(event, callback);
     if (this.getEventListeners().length > 1) return;
 
-    ESLEventUtils.subscribe(this.target, {event: 'pointerdown', capture: false}, this.handleStart);
-    ESLEventUtils.subscribe(this.target, {event: 'pointerup', capture: false}, this.handleEnd);
+    const {target} = this;
+    ESLEventUtils.subscribe(this, {event: 'pointerdown', capture: false, target}, this.handleStart);
+    ESLEventUtils.subscribe(this, {event: 'pointerup', capture: false, target}, this.handleEnd);
   }
 
   /**
@@ -161,7 +162,6 @@ export class ESLSwipeGestureTarget extends SyntheticEventTarget {
     super.removeEventListener(event, callback);
     if (this.getEventListeners().length > 0) return;
 
-    ESLEventUtils.unsubscribe(this.target, 'pointerdown');
-    ESLEventUtils.unsubscribe(this.target, 'pointerup');
+    ESLEventUtils.unsubscribe(this);
   }
 }

--- a/src/modules/esl-event-listener/core/targets/swipe.target.ts
+++ b/src/modules/esl-event-listener/core/targets/swipe.target.ts
@@ -33,11 +33,17 @@ export class ESLSwipeEventTarget extends SyntheticEventTarget {
     timeout: 500
   };
 
-  protected constructor(public readonly target: HTMLElement, threshold?: string, timeout?: number) {
+  protected constructor(public readonly target: Element, threshold?: string, timeout?: number) {
     super();
     this.config = this.getConfig(threshold, timeout);
   }
 
+  /**
+   * Passes threshold into number and units, creates config from passed threshold and distance values or uses default ones.
+   * @param threshold - the distance threshold (px, vh, vw supported) that must be traveled before a swipe event is triggered.
+   * @param timeout - the time in milliseconds that must elapse between pointerdown and pointerup events before a wipe event is triggered.
+   * @returns ESLSwipeEventTarget configuration {@link SwipeEventTargetConfig}.
+   */
   protected getConfig(threshold?: string, timeout?: number): SwipeEventTargetConfig {
     const config = ESLSwipeEventTarget.defaultConfig;
 
@@ -55,12 +61,22 @@ export class ESLSwipeEventTarget extends SyntheticEventTarget {
     return config;
   }
 
-  public static for($el: HTMLElement | ESLMixinElement, threshold?: string, timeout?: number): ESLSwipeEventTarget {
+  /**
+   * @param $el - the element to listen for swipe events on
+   * @param threshold - the distance threshold (px, vh, vw supported) that must be traveled before a swipe event is triggered. Optional. Defaults to 20px
+   * @param timeout - the time in milliseconds that must elapse between pointerdown and pointerup events before a wipe event is triggered. Optional.
+   * Defaults to 500.
+   * @returns Returns the instance of ESLSwipeEventTarget {@link ESLSwipeEventTarget}.
+   */
+  public static for($el: Element | ESLMixinElement, threshold?: string, timeout?: number): ESLSwipeEventTarget {
     if ($el instanceof ESLMixinElement) return ESLSwipeEventTarget.for($el.$host, threshold, timeout);
 
     return new ESLSwipeEventTarget($el, threshold, timeout);
   }
 
+  /**
+   * Subscribes to pointerup and pointerdown event
+   */
   public override addEventListener(callback: EventListener): void;
   public override addEventListener(event: SwipeEventName, callback: EventListener): void;
   public override addEventListener(event: any, callback: EventListener = event): void {
@@ -71,6 +87,10 @@ export class ESLSwipeEventTarget extends SyntheticEventTarget {
     this.target.addEventListener('pointerup', this.handleEnd.bind(this), false);
   }
 
+  /**
+   * Saves swipe start event target, time when swipe started, pointerdown event and coordinates.
+   * @param e - pointer event
+   */
   protected handleStart(e: PointerEvent): void {
     this.startEl = e.target as HTMLElement;
     this.timeDown = e.timeStamp;
@@ -79,6 +99,10 @@ export class ESLSwipeEventTarget extends SyntheticEventTarget {
     this.yDown = e.clientY;
   }
 
+  /**
+   * Triggers swipe event {@link SwipeEventName} with details {@link SwipeEvent} when pointerup event occurred and threshold and distance match configuration
+   * @param e - pointer event
+   */
   protected handleEnd(e: PointerEvent): void {
     // if the user released on a different target, cancel!
     if (this.startEl !== e.target) return;
@@ -106,6 +130,9 @@ export class ESLSwipeEventTarget extends SyntheticEventTarget {
     this.startEl = null;
   }
 
+  /**
+   * @returns threshold based on number and units
+   */
   protected resolveSwipeThreshold(): number {
     let swipeThreshold = this.config.threshold;
 
@@ -119,6 +146,11 @@ export class ESLSwipeEventTarget extends SyntheticEventTarget {
     return swipeThreshold;
   }
 
+  /**
+   * Returns swipe direction based on distance between swipe start and end points
+   * @param e - pointer event
+   * @returns direction of swipe {@link SwipeDirection}
+   */
   protected resolveDirection(e: PointerEvent): SwipeDirection {
     const xDiff = this.xDown - e.clientX;
     const yDiff = this.yDown - e.clientY;

--- a/src/modules/esl-event-listener/core/targets/swipe.target.ts
+++ b/src/modules/esl-event-listener/core/targets/swipe.target.ts
@@ -164,7 +164,8 @@ export class ESLSwipeEventTarget extends SyntheticEventTarget {
       return yDiff > 0 ? 'up' : 'down';
     }
 
-    return 'left';
+    // Marker that there was not enough move characteristic to consider pointer move as touch swipe
+    return null; 
   }
 
   /** Unsubscribes from the observed target {@link Element} changes */

--- a/src/modules/esl-event-listener/core/targets/swipe.target.ts
+++ b/src/modules/esl-event-listener/core/targets/swipe.target.ts
@@ -22,7 +22,7 @@ interface SwipeEventTargetConfig {
  * Describes settings object that could be passed to {@link ESLSwipeGestureTarget.for} as optional parameter
  */
 export interface ESLSwipeGestureSetting {
-  threshold?: string;
+  threshold?: CSSSize;
   timeout?: number;
 }
 
@@ -126,7 +126,7 @@ export class ESLSwipeGestureTarget extends SyntheticEventTarget {
    * @returns direction of swipe {@link SwipeDirection}
    */
   protected resolveDirection(diff: EventsDiff): SwipeDirection | null {
-    const swipeThreshold = resolveCSSSize(this.config.threshold);
+    const swipeThreshold = (resolveCSSSize(this.config.threshold) || resolveCSSSize(ESLSwipeGestureTarget.defaultConfig.threshold)!);
 
     if (Math.abs(diff.x) > Math.abs(diff.y) && Math.abs(diff.x) > swipeThreshold && diff.time < this.config.timeout) {
       return diff.x > 0 ? 'left' : 'right';

--- a/src/modules/esl-event-listener/core/targets/swipe.target.ts
+++ b/src/modules/esl-event-listener/core/targets/swipe.target.ts
@@ -20,9 +20,9 @@ interface SwipeEventTargetConfig {
 }
 
 export class SwipeEventTarget extends SyntheticEventTarget {
-  protected xDown: number | null;
-  protected yDown: number | null;
-  protected timeDown: number | null;
+  protected xDown: number;
+  protected yDown: number;
+  protected timeDown: number;
   protected startEl: HTMLElement | null;
   protected startEvent: PointerEvent;
   protected config: SwipeEventTargetConfig;
@@ -103,9 +103,6 @@ export class SwipeEventTarget extends SyntheticEventTarget {
     }
 
     // reset values
-    this.xDown = null;
-    this.yDown = null;
-    this.timeDown = null;
     this.startEl = null;
   }
 
@@ -134,6 +131,8 @@ export class SwipeEventTarget extends SyntheticEventTarget {
     if (Math.abs(yDiff) > swipeThreshold && timeDiff < this.config.timeout) {
       return yDiff > 0 ? 'up' : 'down';
     }
+
+    return 'left';
   }
 
   /** Unsubscribes from the observed target {@link Element} changes */

--- a/src/modules/esl-utils/dom/test/units.test.ts
+++ b/src/modules/esl-utils/dom/test/units.test.ts
@@ -1,4 +1,5 @@
 import {resolveCSSSize} from '../units';
+import type {CSSSize} from '../units';
 
 describe('resolveCSSSize tests', () => {
   test('resolveCSSSize called with value \'25px\' should return 25', () => {
@@ -21,5 +22,16 @@ describe('resolveCSSSize tests', () => {
   test('resolveCSSSize called with value \'25\' should return 25 as a number', () => {
     const result = resolveCSSSize('25');
     expect(result).toStrictEqual(25);
+  });
+
+  test('resolveCSSSize called with value \'undefined\' should return null', () => {
+    const result = resolveCSSSize(('undefined' as CSSSize));
+    expect(result).toStrictEqual(null);
+  });
+
+  test('resolveCSSSize called with value \'.5vw\' should return 1 (rounded value)', () => {
+    jest.spyOn(document.documentElement, 'clientWidth', 'get').mockImplementation(() => 100);
+    const result = resolveCSSSize('.5vw');
+    expect(result).toStrictEqual(1);
   });
 });

--- a/src/modules/esl-utils/dom/test/units.test.ts
+++ b/src/modules/esl-utils/dom/test/units.test.ts
@@ -1,0 +1,25 @@
+import {resolveCSSSize} from '../units';
+
+describe('resolveCSSSize tests', () => {
+  test('resolveCSSSize called with value \'25px\' should return 25', () => {
+    const result = resolveCSSSize('25px');
+    expect(result).toStrictEqual(25);
+  });
+
+  test('resolveCSSSize called with value \'25vw\' should return 25', () => {
+    jest.spyOn(document.documentElement, 'clientWidth', 'get').mockImplementation(() => 100);
+    const result = resolveCSSSize('25vw');
+    expect(result).toStrictEqual(25);
+  });
+
+  test('resolveCSSSize called with value \'25vh\' should return 25', () => {
+    jest.spyOn(document.documentElement, 'clientHeight', 'get').mockImplementation(() => 100);
+    const result = resolveCSSSize('25vh');
+    expect(result).toStrictEqual(25);
+  });
+
+  test('resolveCSSSize called with value \'25\' should return 25 as a number', () => {
+    const result = resolveCSSSize('25');
+    expect(result).toStrictEqual(25);
+  });
+});

--- a/src/modules/esl-utils/dom/units.ts
+++ b/src/modules/esl-utils/dom/units.ts
@@ -1,0 +1,19 @@
+export type CSSSize = `${number}${'' | 'px' | 'vh' | 'vw'}`;
+
+/**
+ * @param value - CSS value string in px, vh, vw or without units. {@link CSSSize}
+ * @returns number in pixels.
+ */
+export const resolveCSSSize = (value: CSSSize): number => {
+  let num = parseInt(value, 10);
+  const units = value.replace(num.toString(), '');
+
+  if (units === 'vh') {
+    num = Math.round((num / 100) * document.documentElement.clientHeight); // get percentage of viewport height in pixels
+  }
+  if (units === 'vw') {
+    num = Math.round((num / 100) * document.documentElement.clientWidth); // get percentage of viewport width in pixels
+  }
+
+  return num;
+};

--- a/src/modules/esl-utils/dom/units.ts
+++ b/src/modules/esl-utils/dom/units.ts
@@ -5,14 +5,14 @@ export type CSSSize = `${number}${'' | 'px' | 'vh' | 'vw'}`;
  * @returns number in pixels.
  */
 export const resolveCSSSize = (value: CSSSize): number => {
-  let num = parseInt(value, 10);
+  const num = parseInt(value, 10);
   const units = value.replace(num.toString(), '');
 
   if (units === 'vh') {
-    num = Math.round((num / 100) * document.documentElement.clientHeight); // get percentage of viewport height in pixels
+    return Math.round((num / 100) * document.documentElement.clientHeight); // get percentage of viewport height in pixels
   }
   if (units === 'vw') {
-    num = Math.round((num / 100) * document.documentElement.clientWidth); // get percentage of viewport width in pixels
+    return Math.round((num / 100) * document.documentElement.clientWidth); // get percentage of viewport width in pixels
   }
 
   return num;

--- a/src/modules/esl-utils/dom/units.ts
+++ b/src/modules/esl-utils/dom/units.ts
@@ -4,9 +4,20 @@ export type CSSSize = `${number}${'' | 'px' | 'vh' | 'vw'}`;
  * @param value - CSS value string in px, vh, vw or without units. {@link CSSSize}
  * @returns number in pixels.
  */
-export const resolveCSSSize = (value: CSSSize): number => {
-  const num = parseInt(value, 10);
-  const units = value.replace(num.toString(), '');
+export const resolveCSSSize = (value: CSSSize): number | null => {
+  let units = 'px';
+
+  ['px', 'vh', 'vw'].forEach((item) => {
+    if (value.indexOf(item) > 0) {
+      units = item;
+    }
+  });
+
+  const num = parseFloat(value.replace(units, ''));
+
+  if (!num) {
+    return null;
+  }
 
   if (units === 'vh') {
     return Math.round((num / 100) * document.documentElement.clientHeight); // get percentage of viewport height in pixels


### PR DESCRIPTION
Add SwipeEventTarget to subscribe `swipe`, `swipe:left`, `swipe:right`, `swipe:up`, `swipe:down` events using `ESLEventUtils.subscribe` or `@listen` descriptor

Closes: #1809 
