### PR TITLE
chore: update watch:eleventy stating script

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "build-pages:analyzer": "cd pages && webpack --mode=production --profile --json ../.report/stats.json && webpack-bundle-analyzer ../.report/stats.json ../pages/dist/bundles -s gzip -m static -r ../.report/stats.html",
     "watch:ts": "cd pages && webpack --watch",
     "watch:less": "chokidar --initial \"**/*.less\" -c \"npm run build-pages:less\"",
-    "watch:eleventy": "cd pages && npx @11ty/eleventy --serve --incremental --port=3005 -- --env=development",
+    "watch:eleventy": "cd pages && npx @11ty/eleventy --serve --incremental -- --env=development",
     "test": "concurrently \"npm run lint\" \"npm run test:unit\"",
     "test:ci": "jest --coverage --silent --noStackTrace",
     "test:unit": "jest --silent --noStackTrace",


### PR DESCRIPTION
Removed redundant port definition from script command. The port number definition in the e11ty config is left. 