### PR TITLE
feat(esl-utils): `lockScroll` / `unlockScroll` methods reworked with no-scroll detection

### DIFF
--- a/src/modules/esl-utils/dom/scroll.less
+++ b/src/modules/esl-utils/dom/scroll.less
@@ -13,46 +13,33 @@ html[esl-scroll-lock] body {
 html[esl-scroll-lock='native'] {
   overflow-y: scroll !important;
 
+  &[esl-scroll-lock-passive] {
+    overflow-y: hidden !important;
+  }
+
   body {
     max-width: 100vw !important;
     max-height: 100vh !important;
   }
 }
 
-html[esl-scroll-lock='pseudo'] {
-  display: flex !important;
-  align-items: stretch !important;
+html[esl-scroll-lock='pseudo'],
+html[esl-scroll-lock='background'] {
+  --s-lock-offset: 0;
+  padding-right: var(--s-lock-offset);
 
-  &:dir(rtl) {
-    flex-flow: row-reverse !important;
-  }
-
-  body {
-    flex: 1 1 100% !important;
-  }
-
-  &::before {
-    content: '';
-    overflow-y: scroll;
-    flex: 0 0 auto;
-    order: 2;
-    visibility: hidden;
-  }
-
-  &::after {
+  &:not([esl-scroll-lock-passive])::after {
     content: '';
     position: fixed;
     top: 0;
     right: 0;
     bottom: 0;
     overflow-y: scroll;
-    // Pseudo scroll should be visible above the content
-    z-index: 999999;
+    z-index: 1;
   }
+}
 
-  // hide analytics beacons and markers
-  & > img,
-  & > iframe {
-    flex: 0 1 auto !important;
-  }
+html[esl-scroll-lock='pseudo']:not([esl-scroll-lock-passive])::after {
+  // Pseudo scroll should be visible above the content
+  z-index: 999999;
 }

--- a/src/modules/esl-utils/dom/scroll/utils.ts
+++ b/src/modules/esl-utils/dom/scroll/utils.ts
@@ -2,20 +2,18 @@ import {getScrollParent} from './parent';
 
 const $html = document.documentElement;
 
-const initiatorMap = new WeakMap<Element, any[]>();
-
 /** Checks if element is blocked from scrolling */
 export function isScrollLocked(target: Element): boolean {
   return target.hasAttribute('esl-scroll-lock');
 }
 
 /** Checks vertical scroll based on content height */
-export function hasVerticalScroll(target = $html): boolean {
+export function hasVerticalScroll(target: Element = $html): boolean {
   return target.scrollHeight > target.clientHeight;
 }
 
-/** Checks  horizontal scroll based on content height */
-export function hasHorizontalScroll(target = $html): boolean {
+/** Checks horizontal scroll based on content height */
+export function hasHorizontalScroll(target: Element = $html): boolean {
   return target.scrollWidth > target.clientWidth;
 }
 
@@ -24,57 +22,63 @@ export type ScrollLockOptions = {
    * Option to lock scroll:
    * - 'none' | null | undefined - totally locks scroll with `overflow: hidden` option
    * - 'native' (applicable for page only) - left page scroll visible but inactive
-   * - 'pseudo' (applicable for page only) - uses special flexbox hack on the page,
-   * to make page static on lock but with capability to overlap the scroll
+   * - 'pseudo' (applicable for page only) - uses padding offset to make page static on lock
+   * - 'background' (applicable for page only) - uses padding offset to make page static on lock and uses small pseudo-scrollbar z-index
    */
-  strategy?: 'none' | 'native' | 'pseudo' | null;
+  strategy?: 'none' | 'native' | 'pseudo' | 'background' | null;
   /** Locks all scrollable parents */
   recursive?: boolean;
   /** Initiator (requester) object to limit lock operations by the query */
   initiator?: any;
 };
 
+// Scroll lock mutex holder
+const initiatorMap = new WeakMap<Element, any[]>();
+/** Occupy inner mutex of scroll lock */
+const requestLock = (target: Element, initiator: any): void => {
+  if (!initiator) return;
+  const initiatorList = initiatorMap.get(target) || [];
+  const index = initiatorList.indexOf(initiator);
+  if (index === -1) initiatorList.push(initiator);
+  initiatorMap.set(target, initiatorList);
+};
+
+/** Free inner mutex of the scroll lock */
+const requestUnlock = (target: Element, initiator: any): boolean => {
+  const initiatorList = initiatorMap.get(target) || [];
+  const index = initiatorList.indexOf(initiator);
+  if (index >= 0) initiatorList.splice(index, 1);
+  if (!initiatorList.length || !initiator) initiatorMap.delete(target);
+  return !initiatorMap.has(target);
+};
+
 /**
- * Disables scroll on the element.
+ * Disables a scroll on the element.
  * @param target - scrollable element which will be blocked from scrolling
  * @param options - additional options to lock scroll
  * */
 export function lockScroll(target: Element = $html, options: ScrollLockOptions = {}): void {
-  const {initiator} = options;
-  if (initiator) {
-    const initiatorList = initiatorMap.get(target);
-    if (initiatorList) {
-      if (initiatorList.includes(initiator)) return;
-      initiatorList.push(initiator);
-      if (initiatorList.length > 1) return;
-    } else {
-      initiatorMap.set(target, [initiator]);
-    }
-  }
-
+  requestLock(target, options.initiator);
   const scrollable = target === $html ? target : getScrollParent(target);
+  const hasVScroll = hasVerticalScroll(scrollable);
+  if (scrollable === $html && hasVScroll) {
+    const scrollWidth = window.innerWidth - document.documentElement.clientWidth;
+    $html.style.setProperty('--s-lock-offset', `${scrollWidth}px`);
+  }
+  scrollable.toggleAttribute('esl-scroll-lock-passive', !hasVScroll);
   scrollable.setAttribute('esl-scroll-lock', options.strategy || '');
   if (options.recursive && scrollable.parentElement) lockScroll(scrollable.parentElement, options);
 }
 
 /**
- * Enables scroll on the target element in case it was requested with given initiator.
+ * Enables a scroll on the target element in case it was requested with given initiator.
  * @param target - scrollable element
  * @param options - additional options to unlock scroll
  */
 export function unlockScroll(target: Element = $html, options: ScrollLockOptions = {}): void {
-  const {initiator} = options;
-  if (initiator) {
-    const initiatorList = initiatorMap.get(target);
-    if (!initiatorList) return;
-    const index = initiatorList.indexOf(initiator);
-    if (index >= 0) initiatorList.splice(index, 1);
-    if (initiatorList.length > 0) return;
-  } else {
-    initiatorMap.delete(target);
-  }
-
+  if (!requestUnlock(target, options.initiator)) return;
   const scrollable = target === $html ? target : getScrollParent(target);
+  scrollable.removeAttribute('esl-scroll-lock-passive');
   scrollable.removeAttribute('esl-scroll-lock');
   if (options.recursive && scrollable.parentElement) unlockScroll(scrollable.parentElement, options);
 }

--- a/src/modules/esl-utils/dom/scroll/utils.ts
+++ b/src/modules/esl-utils/dom/scroll/utils.ts
@@ -61,7 +61,7 @@ export function lockScroll(target: Element = $html, options: ScrollLockOptions =
   requestLock(target, options.initiator);
   const scrollable = target === $html ? target : getScrollParent(target);
   const hasVScroll = hasVerticalScroll(scrollable);
-  if (scrollable === $html && hasVScroll) {
+  if (scrollable === $html) {
     const scrollWidth = window.innerWidth - document.documentElement.clientWidth;
     $html.style.setProperty('--s-lock-offset', `${scrollWidth}px`);
   }


### PR DESCRIPTION
- `pseudo` scroll lock now uses padding hack instead of flexbox on the html level
- new `background` type of lock repeats `pseudo` but with much more lower default `z-index` for scrollbar stub
