### PR TITLE
fix(esl-event-listener): `ESLResizeObserverTarget.for` handles no target cases silently (warning + null result)

### DIFF
--- a/src/modules/esl-event-listener/core/targets/resize.adapter.ts
+++ b/src/modules/esl-event-listener/core/targets/resize.adapter.ts
@@ -1,4 +1,5 @@
 import {SyntheticEventTarget} from '../../../esl-utils/dom/events/target';
+import {isElement} from '../../../esl-utils/dom/api';
 import {resolveDomTarget} from '../../../esl-utils/abstract/dom-target';
 import {ESLElementResizeEvent} from './resize.adapter.event';
 
@@ -29,16 +30,20 @@ export class ESLResizeObserverTarget extends SyntheticEventTarget {
   }
 
   /** Creates {@link ESLResizeObserverTarget} instance for the {@link ESLDomElementTarget} */
-  public static for(target: ESLDomElementTarget): ESLResizeObserverTarget {
-    return new ESLResizeObserverTarget(target);
+  public static for(target: ESLDomElementTarget): ESLResizeObserverTarget;
+  public static for(target: ESLDomElementTarget): ESLResizeObserverTarget | null {
+    const $target = resolveDomTarget(target);
+    if (isElement($target)) return new ESLResizeObserverTarget($target);
+    // Error handling
+    console.warn('[ESL]: ESLResizeObserverTarget can not observe %o', target);
+    return null;
   }
 
   /**
    * Creates {@link ESLResizeObserverTarget} for the {@link ESLDomElementTarget}.
    * Note the {@link ESLResizeObserverTarget} instances are singletons relatively to the {@link Element}
    */
-  protected constructor(target: ESLDomElementTarget) {
-    target = resolveDomTarget(target);
+  protected constructor(target: Element) {
     const instance = ESLResizeObserverTarget.mapping.get(target);
     if (instance) return instance;
 

--- a/src/modules/esl-event-listener/test/targets/resize.test.ts
+++ b/src/modules/esl-event-listener/test/targets/resize.test.ts
@@ -16,6 +16,32 @@ describe('ESLEventUtils: ResizeObserver EventTarget adapter', () => {
     );
   });
 
+  describe('ESLResizeObserverTarget do not throws error on incorrect input (silent processing)', () => {
+    const consoleSpy = jest.spyOn(console, 'warn');
+    beforeEach(() => consoleSpy.mockReset().mockImplementation(() => void 0));
+    afterAll(() => consoleSpy.mockRestore());
+
+    test('ESLResizeObserverTarget.for(undefined) returns null without error', () => {
+      expect(ESLResizeObserverTarget.for(undefined as any)).toBeNull();
+      expect(consoleSpy).toBeCalled();
+    });
+
+    test('ESLResizeObserverTarget.for(null) returns null without error', () => {
+      expect(ESLResizeObserverTarget.for(null as any)).toBeNull();
+      expect(consoleSpy).toBeCalled();
+    });
+
+    test('ESLResizeObserverTarget.for(123) returns null without error', () => {
+      expect(ESLResizeObserverTarget.for(123 as any)).toBeNull();
+      expect(consoleSpy).toBeCalled();
+    });
+
+    test('ESLResizeObserverTarget.for({}) returns null without error', () => {
+      expect(ESLResizeObserverTarget.for({} as any)).toBeNull();
+      expect(consoleSpy).toBeCalled();
+    });
+  });
+
   describe('ESLResizeObserverTarget livecycle', () => {
     describe('Element as a taget', () => {
       const mock = getLastResizeObserverMock();


### PR DESCRIPTION
Closes: #1885