### PR TITLE
chore: ignore lint-staged action in case merge commit processing locally

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx lint-staged --verbose --quiet
+# ignore lint-staged if it is merge commit
+git rev-parse -q --no-revs --verify MERGE_HEAD || npx lint-staged --verbose --quiet


### PR DESCRIPTION
Have you ever encountered a situation where you couldn't merge a branch because lint-staged had validated it? Say goodbye to self-managed merge messages and the frustration of rejections for code that isn't yours)