### PR TITLE
feat(esl-panel-group): add ability to enable match-height behavior for tabs height using `esl-tabs-equal-height` class

### DIFF
--- a/pages/views/examples/tabs.njk
+++ b/pages/views/examples/tabs.njk
@@ -57,20 +57,77 @@ aside:
     <esl-panel-group class="esl-d-tab-group"
                      mode="tabs"
                      mode-cls-target="::parent">
-      {% set testText = lorem.paragraphs(2) %}
       <esl-panel class="esl-d-tab-panel tab-1" tabindex="0">
         <div class="esl-d-tab-body">
-          {{ testText }}
+          {{ lorem.paragraphs(2) }}
         </div>
       </esl-panel>
       <esl-panel open class="esl-d-tab-panel tab-2" tabindex="0">
         <div class="esl-d-tab-body">
-          {{ testText }}
+          {{ lorem.paragraphs(2) }}
         </div>
       </esl-panel>
       <esl-panel class="esl-d-tab-panel tab-3" tabindex="0">
         <div class="esl-d-tab-body">
           {{ lorem.paragraphs(3) }}
+        </div>
+      </esl-panel>
+    </esl-panel-group>
+  </div>
+</section>
+
+<section>
+  <h2>Simple Tabs (Match Height)</h2>
+  <p>Minimum configuration example</p>
+  {% code 'html', 'code-block' %}
+    <esl-tabs class="esl-d-tab-control"/>
+    <esl-panel-group class="esl-d-tab-group esl-tabs-equal-height"
+                     mode="tabs"
+                     mode-cls-target="::parent"/>
+  {% endcode %}
+
+  <div class="esl-d-tabs">
+    <esl-tabs class="esl-d-tab-control">
+      <esl-a11y-group targets="::find(esl-tab)" activate-selected></esl-a11y-group>
+
+      <ul class="esl-d-tab-list esl-tab-container" role="tablist">
+        <li class="esl-d-tab-item">
+          <esl-tab class="h5"
+                   target="::parent(.esl-d-tabs)::find(.tab-1)">
+            Tab #1 Lorem ipsum
+          </esl-tab>
+        </li>
+        <li class="esl-d-tab-item">
+          <esl-tab class="h5"
+                   target="::parent(.esl-d-tabs)::find(.tab-2)">
+            Tab #2 Lorem ipsum
+          </esl-tab>
+        </li>
+        <li class="esl-d-tab-item">
+          <esl-tab class="h5"
+                   target="::parent(.esl-d-tabs)::find(.tab-3)">
+            Tab #3 Lorem ipsum
+          </esl-tab>
+        </li>
+      </ul>
+    </esl-tabs>
+
+    <esl-panel-group class="esl-d-tab-group esl-tabs-equal-height"
+                     mode="tabs"
+                     mode-cls-target="::parent">
+      <esl-panel class="esl-d-tab-panel tab-1" tabindex="0">
+        <div class="esl-d-tab-body">
+          {{ lorem.paragraphs(2) }}
+        </div>
+      </esl-panel>
+      <esl-panel open class="esl-d-tab-panel tab-2" tabindex="0">
+        <div class="esl-d-tab-body">
+          {{ lorem.paragraphs(3) }}
+        </div>
+      </esl-panel>
+      <esl-panel class="esl-d-tab-panel tab-3" tabindex="0">
+        <div class="esl-d-tab-body">
+          {{ lorem.paragraphs(1) }}
         </div>
       </esl-panel>
     </esl-panel-group>

--- a/src/modules/esl-panel-group/core/esl-panel-group.less
+++ b/src/modules/esl-panel-group/core/esl-panel-group.less
@@ -26,6 +26,15 @@ esl-panel-group {
       }
     }
   }
+
+  &[current-mode='tabs'].esl-tabs-equal-height {
+    display: grid;
+    grid-template-areas: 'stack';
+    > esl-panel {
+      grid-area: stack;
+      max-height: none;
+    }
+  }
 }
 
 // fix a11y


### PR DESCRIPTION
Closes: #1949
