### PR TITLE
fix(esl-media): fix loading class condition should ignore lazy state

### DIFF
--- a/src/modules/esl-media/core/esl-media.ts
+++ b/src/modules/esl-media/core/esl-media.ts
@@ -105,14 +105,28 @@ export class ESLMedia extends ESLBaseElement {
   /** Ready state class/classes target */
   @attr() public readyClassTarget: string;
 
-  /** Class / classes to add when media is accepted */
+  /**
+   * Class / classes to add when media is accepted
+   * @deprecated use {@link loadConditionClass} instead (e.g. `load-condition-class="is-accepted"`)
+   */
   @attr() public loadClsAccepted: string;
-  /** Class / classes to add when media is declined */
+  /**
+   * Class / classes to add when media is declined
+   * @deprecated use {@link loadConditionClass} with negative class param instead (e.g. `load-condition-class="!is-declined"`)
+   */
   @attr() public loadClsDeclined: string;
+  /**
+   * Target element {@link ESLTraversingQuery} select to add accepted/declined classes
+   * @deprecated used with legacy load condition attributes, consider migration to {@link loadConditionClass}
+   */
+  @attr({defaultValue: '::parent'}) public loadClsTarget: string;
+
   /** Condition {@link ESLMediaQuery} to allow load of media resource. Default: `all` */
   @attr({defaultValue: 'all'}) public loadCondition: string;
-  /** Target element {@link ESLTraversingQuery} select to add accepted/declined classes */
-  @attr({defaultValue: '::parent'}) public loadClsTarget: string;
+  /** Class / classes to add when load media is accepted */
+  @attr() public loadConditionClass: string;
+  /** Target element {@link ESLTraversingQuery} select to toggle {@link loadConditionClass} classes */
+  @attr({defaultValue: '::parent'}) public loadConditionClassTarget: string;
 
   /** @readonly Ready state marker */
   @boolAttr({readonly: true}) public ready: boolean;
@@ -234,12 +248,15 @@ export class ESLMedia extends ESLBaseElement {
   }
 
   public updateContainerMarkers(): void {
-    const targetEl = ESLTraversingQuery.first(this.loadClsTarget, this) as HTMLElement;
-    if (!targetEl) return;
+    const active = this.conditionQuery.matches;
 
-    const active = this.canActivate();
-    CSSClassUtils.toggle(targetEl, this.loadClsAccepted, active);
-    CSSClassUtils.toggle(targetEl, this.loadClsDeclined, !active);
+    const $target = ESLTraversingQuery.first(this.loadConditionClassTarget, this) as HTMLElement;
+    $target && CSSClassUtils.toggle($target, this.loadConditionClass, active);
+
+    // Legacy attributes support
+    const targetEl = ESLTraversingQuery.first(this.loadClsTarget, this) as HTMLElement;
+    targetEl && CSSClassUtils.toggle(targetEl, this.loadClsAccepted, active);
+    targetEl && CSSClassUtils.toggle(targetEl, this.loadClsDeclined, !active);
   }
 
   /** Seek to given position of media */

--- a/src/modules/esl-media/test/esl-media.condition.test.ts
+++ b/src/modules/esl-media/test/esl-media.condition.test.ts
@@ -1,0 +1,163 @@
+import '../providers/html5/video-provider';
+
+import {ESLMedia} from '../core';
+import {promisifyTimeout} from '../../esl-utils/async/promise';
+import {IntersectionObserverMock} from '../../esl-utils/test/intersectionObserver.mock';
+import {getMatchMediaMock} from '../../esl-utils/test/matchMedia.mock';
+
+describe('esl-media: lazy loading unit tests', () => {
+  beforeAll(() => {
+    IntersectionObserverMock.mock();
+    ESLMedia.register();
+  });
+  afterAll(() => IntersectionObserverMock.unmock());
+
+  const createMedia = (props: Partial<ESLMedia>) => {
+    const $media = ESLMedia.create();
+    Object.assign($media, {
+      mediaSrc: 'https://esl-ui.com/assets/media/video.mp4'
+    }, props);
+    return $media;
+  };
+  afterEach(() => {
+    while (document.body.firstChild) document.body.removeChild(document.body.firstChild);
+  });
+
+  test('ESLMedia checks the load condition before load', async () => {
+    const $media = createMedia({loadCondition: 'not all'});
+    document.body.appendChild($media);
+
+    await promisifyTimeout(100);
+    expect($media.querySelectorAll('*')).toEqual(expect.objectContaining({length: 0}));
+  });
+
+  test('ESLMedia loads as soon as load condition become truthy', async () => {
+    const mqMock = getMatchMediaMock('(min-width: 100px)');
+    const $media = createMedia({loadCondition: '(min-width: 100px)'});
+    document.body.appendChild($media);
+
+    await promisifyTimeout(100);
+    expect($media.querySelectorAll('*')).toEqual(expect.objectContaining({length: 0}));
+
+    mqMock.set(true);
+    await promisifyTimeout(100);
+    expect($media.querySelectorAll('*')).not.toEqual(expect.objectContaining({length: 0}));
+  });
+
+  describe('ESLMedia legacy load condition classes', () => {
+    test('ESLMedia declining condition leads to "declined" class on the target', async () => {
+      const $media = createMedia({
+        loadCondition: 'not all',
+        loadClsTarget: 'body',
+        loadClsAccepted: 'accepted',
+        loadClsDeclined: 'declined'
+      });
+      document.body.appendChild($media);
+
+      await promisifyTimeout(100);
+      expect(document.body.classList.contains('accepted')).toBe(false);
+      expect(document.body.classList.contains('declined')).toBe(true);
+    });
+
+    test('ESLMedia accepting condition leads to "accepted" class on the target', async () => {
+      const $media = createMedia({
+        loadCondition: 'all',
+        loadClsTarget: 'body',
+        loadClsAccepted: 'accepted',
+        loadClsDeclined: 'declined'
+      });
+      document.body.appendChild($media);
+
+      await promisifyTimeout(100);
+      expect(document.body.classList.contains('accepted')).toBe(true);
+      expect(document.body.classList.contains('declined')).toBe(false);
+    });
+
+    test('ESLMedia load condition does not clock "declined" class on the target', async () => {
+      const $media = createMedia({
+        lazy: 'manual',
+        loadCondition: 'not all',
+        loadClsTarget: 'body',
+        loadClsAccepted: 'accepted',
+        loadClsDeclined: 'declined'
+      });
+      document.body.appendChild($media);
+
+      await promisifyTimeout(100);
+      expect(document.body.classList.contains('accepted')).toBe(false);
+      expect(document.body.classList.contains('declined')).toBe(true);
+    });
+
+    test('ESLMedia load condition does not clock "accepted" class on the target', async () => {
+      const $media = createMedia({
+        lazy: 'manual',
+        loadCondition: 'all',
+        loadClsTarget: 'body',
+        loadClsAccepted: 'accepted',
+        loadClsDeclined: 'declined'
+      });
+      document.body.appendChild($media);
+
+      await promisifyTimeout(100);
+      expect(document.body.classList.contains('accepted')).toBe(true);
+      expect(document.body.classList.contains('declined')).toBe(false);
+    });
+  });
+
+
+  describe('ESLMedia load condition classes', () => {
+    test('ESLMedia declining condition leads to "declined" class on the target', async () => {
+      const $media = createMedia({
+        loadCondition: 'not all',
+        loadConditionClass: 'accepted !declined',
+        loadConditionClassTarget: 'body'
+      });
+      document.body.appendChild($media);
+
+      await promisifyTimeout(100);
+      expect(document.body.classList.contains('accepted')).toBe(false);
+      expect(document.body.classList.contains('declined')).toBe(true);
+    });
+
+    test('ESLMedia accepting condition leads to "accepted" class on the target', async () => {
+      const $media = createMedia({
+        loadCondition: 'all',
+        loadConditionClass: 'accepted !declined',
+        loadConditionClassTarget: 'body'
+      });
+      document.body.appendChild($media);
+
+      await promisifyTimeout(100);
+      expect(document.body.classList.contains('accepted')).toBe(true);
+      expect(document.body.classList.contains('declined')).toBe(false);
+    });
+
+    test('ESLMedia load condition does not clock "declined" class on the target', async () => {
+      const $media = createMedia({
+        lazy: 'manual',
+        loadCondition: 'not all',
+        loadConditionClass: 'accepted !declined',
+        loadConditionClassTarget: 'body'
+      });
+      document.body.appendChild($media);
+
+      await promisifyTimeout(100);
+      expect(document.body.classList.contains('accepted')).toBe(false);
+      expect(document.body.classList.contains('declined')).toBe(true);
+    });
+
+    test('ESLMedia load condition does not clock "accepted" class on the target', async () => {
+      const $media = createMedia({
+        lazy: 'manual',
+        loadCondition: 'all',
+        loadConditionClass: 'accepted !declined',
+        loadConditionClassTarget: 'body'
+      });
+      document.body.appendChild($media);
+
+      await promisifyTimeout(100);
+      expect(document.body.classList.contains('accepted')).toBe(true);
+      expect(document.body.classList.contains('declined')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
IMPORTANT: `loadClsAccepted` / `loadClsDeclined` with `loadClsTarget` now deprecated, use `loadConditionClass` + `loadConditionClassTarget` instead