### PR TITLE
ESL Open State Mixin to produce show/open actions on marked esl-toggleable instance

### DIFF
--- a/pages/src/localdev.ts
+++ b/pages/src/localdev.ts
@@ -34,7 +34,8 @@ import {
   ESLTooltip,
   ESLAnimate,
   ESLAnimateMixin,
-  ESLRelatedTarget
+  ESLRelatedTarget,
+  ESLOpenState
 } from '@exadel/esl/modules/all';
 
 import {ESLRandomText} from '@exadel/esl/modules/esl-random-text/core';
@@ -119,6 +120,7 @@ ESLAnimateMixin.register();
 
 // Register ESL Mixins
 ESLRelatedTarget.register();
+ESLOpenState.register();
 
 // Share component loading
 import (/* webpackChunkName: 'common/esl-share' */'./esl-share/esl-share');

--- a/pages/views/components/esl-toggleable.njk
+++ b/pages/views/components/esl-toggleable.njk
@@ -22,3 +22,7 @@ aside:
 <hr/>
 <h3 class="mb-4">ESL Related Target</h3>
 {% mdRender 'src/modules/esl-related-target/README.md', 'intro' %}
+<hr/>
+
+<h3 class="mb-4">ESL Open State</h3>
+{% mdRender 'src/modules/esl-open-state/README.md', 'intro' %}

--- a/pages/views/examples/toggleable.njk
+++ b/pages/views/examples/toggleable.njk
@@ -279,3 +279,28 @@ aside:
     </div>
   </div>
 </section>
+<hr/>
+
+<section class="row">
+  <div class="col-12">
+    <h4>Example with Open State</h4>
+    <div style="min-height: 70px;">
+      <esl-toggleable id="toggleable-open-state"
+                      body-class="toggleable-opened"
+                      esl-open-state="@+MD"
+                      close-on=".close-button"
+                      close-on-esc>
+        <div class="alert alert-warning" role="alert">
+          <strong>This is a toggleable.</strong> It is open on @+MD using Open State.
+          <button type="button" class="close close-button" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+      </esl-toggleable>
+    </div>
+    <p>Triggers</p>
+    <div class="btn-container">
+      <esl-trigger target="#toggleable-open-state" mode="toggle" a11y-label-active a11y-label-inactive="expand" class="btn btn-sec-blue">Toggle</esl-trigger>
+    </div>
+  </div>
+</section>

--- a/src/modules/all.ts
+++ b/src/modules/all.ts
@@ -24,6 +24,9 @@ export * from './esl-panel-group/core';
 
 export * from './esl-popup/core';
 
+// Open State Mixin
+export * from './esl-open-state/core';
+
 // Scrollbar
 export * from './esl-scrollbar/core';
 

--- a/src/modules/esl-open-state/README.md
+++ b/src/modules/esl-open-state/README.md
@@ -1,0 +1,17 @@
+# [ESL](../../../) Open State Mixin
+
+Version: *1.0.0*
+
+Authors: *Yuliya Adamskaya, Alexey Stsefanovich (ala'n)*.
+
+<a name="intro"></a>
+
+**ESLOpenState** is a custom mixin that can be used in combination with `ESLToggleable` instance (or any inheritor)
+to request opening/closing it by the media query condition.
+
+Mixin attaches to the element via `esl-open-state` attribute.
+The attribute's value defines media query condition to define when `ESLToggleable` element should be open.
+
+```html
+<esl-toggleable esl-open-state="@+MD"></esl-toggleable>
+```

--- a/src/modules/esl-open-state/core.ts
+++ b/src/modules/esl-open-state/core.ts
@@ -1,0 +1,1 @@
+export * from './core/esl-open-state';

--- a/src/modules/esl-open-state/core/esl-open-state.ts
+++ b/src/modules/esl-open-state/core/esl-open-state.ts
@@ -2,7 +2,7 @@ import {ExportNs} from '../../esl-utils/environment/export-ns';
 import {ESLMixinElement} from '../../esl-mixin-element/core';
 import {listen, attr, ready} from '../../esl-utils/decorators';
 import {ESLMediaQuery} from '../../esl-media-query/core';
-import type {ESLToggleable} from '../../esl-toggleable/core/esl-toggleable';
+import {ESLToggleable} from '../../esl-toggleable/core/esl-toggleable';
 import type {ESLMediaChangeEvent} from '../../esl-media-query/core';
 
 /**
@@ -15,20 +15,22 @@ import type {ESLMediaChangeEvent} from '../../esl-media-query/core';
 export class ESLOpenState extends ESLMixinElement {
   static override is = 'esl-open-state';
 
+  public override $host: ESLToggleable;
+
   /** Open state {@link ESLMediaQuery} condition from query string */
   @attr({name: ESLOpenState.is, parser: ESLMediaQuery.for}) public media: ESLMediaQuery;
 
   @ready
   protected override connectedCallback(): void {
     super.connectedCallback();
-    customElements.whenDefined('esl-toggleable').then(() => this.onMediaChange());
+    ESLToggleable.registered.then(() => this.onMediaChange());
   }
 
   /** Handles query change and processes {@link ESLToggleable} toggle event in case query value is matched */
   @listen({event: 'change', target: ($this: ESLMediaChangeEvent) => $this.media})
   protected onMediaChange(): void {
-    (this.$host as ESLToggleable).toggle(this.media.matches, {
-      initiator: 'media',
+    this.$host.toggle(this.media.matches, {
+      initiator: (this.constructor as typeof ESLOpenState).is,
       activator: this.$host
     });
   }

--- a/src/modules/esl-open-state/core/esl-open-state.ts
+++ b/src/modules/esl-open-state/core/esl-open-state.ts
@@ -1,0 +1,35 @@
+import {ExportNs} from '../../esl-utils/environment/export-ns';
+import {ESLMixinElement} from '../../esl-mixin-element/core';
+import {listen, attr, ready} from '../../esl-utils/decorators';
+import {ESLMediaQuery} from '../../esl-media-query/core';
+import type {ESLToggleable} from '../../esl-toggleable/core/esl-toggleable';
+import type {ESLMediaChangeEvent} from '../../esl-media-query/core';
+
+/**
+ * ESLOpenState mixin element
+ * @author Yuliya Adamskaya, Alexey Stsefanovich (ala'n)
+ *
+ * ESLOpenState is a custom mixin element that can be used with {@link ESLToggleable}s to request opening/closing it by the media query condition
+ */
+@ExportNs('OpenState')
+export class ESLOpenState extends ESLMixinElement {
+  static override is = 'esl-open-state';
+
+  /** Open state {@link ESLMediaQuery} condition from query string */
+  @attr({name: ESLOpenState.is, parser: ESLMediaQuery.for}) public media: ESLMediaQuery;
+
+  @ready
+  protected override connectedCallback(): void {
+    super.connectedCallback();
+    customElements.whenDefined('esl-toggleable').then(() => this.onMediaChange());
+  }
+
+  /** Handles query change and processes {@link ESLToggleable} toggle event in case query value is matched */
+  @listen({event: 'change', target: ($this: ESLMediaChangeEvent) => $this.media})
+  protected onMediaChange(): void {
+    (this.$host as ESLToggleable).toggle(this.media.matches, {
+      initiator: 'media',
+      activator: this.$host
+    });
+  }
+}

--- a/src/modules/esl-open-state/test/esl-open-state.test.ts
+++ b/src/modules/esl-open-state/test/esl-open-state.test.ts
@@ -1,0 +1,26 @@
+import {ESLOpenState} from '../core/esl-open-state';
+import {ESLToggleable} from '../../esl-toggleable/core/esl-toggleable';
+import {ESLTestTemplate} from '../../esl-utils/test/template';
+
+describe('ESLOpenState (mixin): tests', () => {
+
+  beforeAll(() => {
+    jest.useFakeTimers();
+
+    ESLToggleable.register();
+    ESLOpenState.register();
+  });
+
+  describe('ESLOpenState: general behaviour tests', () => {
+    const REFERENCES = {
+      origin: 'esl-toggleable#origin-tgbl'
+    };
+    const TEMPLATE = ESLTestTemplate.create(`
+      <esl-toggleable id="origin-tgbl"></esl-toggleable>
+    `, REFERENCES).bind('beforeeach');
+
+    test('ESLOpenState with \'@+MD\' query condition', () => {
+      (TEMPLATE.$origin as ESLToggleable).setAttribute('esl-open-state', '@+MD');
+    });
+  });
+});

--- a/src/modules/esl-open-state/test/esl-open-state.test.ts
+++ b/src/modules/esl-open-state/test/esl-open-state.test.ts
@@ -1,26 +1,77 @@
-import {ESLOpenState} from '../core/esl-open-state';
-import {ESLToggleable} from '../../esl-toggleable/core/esl-toggleable';
-import {ESLTestTemplate} from '../../esl-utils/test/template';
+import {ESLOpenState} from '../core';
+import {ESLToggleable} from '../../esl-toggleable/core';
+import {getMatchMediaMock} from '../../esl-utils/test/matchMedia.mock';
+
+// TODO: consider as default jest loader
+jest.mock('../../esl-utils/dom/ready', () => ({
+  onDocumentReady: (clb: any) => clb()
+}));
 
 describe('ESLOpenState (mixin): tests', () => {
+  const TEST_MQ = '(min-width: 500px)';
+  const twoTicks = () => Promise.resolve().then(() => Promise.resolve());
 
-  beforeAll(() => {
+  beforeAll(async () => {
     jest.useFakeTimers();
 
     ESLToggleable.register();
     ESLOpenState.register();
+
+    await ESLToggleable.registered;
   });
 
-  describe('ESLOpenState: general behaviour tests', () => {
-    const REFERENCES = {
-      origin: 'esl-toggleable#origin-tgbl'
-    };
-    const TEMPLATE = ESLTestTemplate.create(`
-      <esl-toggleable id="origin-tgbl"></esl-toggleable>
-    `, REFERENCES).bind('beforeeach');
+  beforeEach(() => document.body.innerHTML = '');
 
-    test('ESLOpenState with \'@+MD\' query condition', () => {
-      (TEMPLATE.$origin as ESLToggleable).setAttribute('esl-open-state', '@+MD');
-    });
+  test('ESLOpenState initialize correctly', async () => {
+    const $el = ESLToggleable.create();
+    $el.setAttribute(ESLOpenState.is, 'not all');
+    document.body.append($el);
+    await twoTicks();
+    expect(ESLOpenState.get($el)).toEqual(expect.any(ESLOpenState));
+  });
+
+  test('ESLOpenState set up initial closed state if query is falsy', async () => {
+    const $el = ESLToggleable.create();
+    const hideSpy = jest.spyOn($el, 'hide');
+    $el.setAttribute(ESLOpenState.is, 'not all');
+    document.body.append($el);
+    await twoTicks();
+    expect(hideSpy).toHaveBeenCalledWith(expect.objectContaining({initiator: ESLOpenState.is}));
+  });
+
+  test('ESLOpenState set up initial open state if query is active', async () => {
+    const $el = ESLToggleable.create();
+    const showSpy = jest.spyOn($el, 'show');
+    $el.setAttribute(ESLOpenState.is, 'all');
+    document.body.append($el);
+    await twoTicks();
+    expect(showSpy).toHaveBeenCalledWith(expect.objectContaining({initiator: ESLOpenState.is}));
+  });
+
+  test('ESLOpenState calls ESLTogleable\'s show on media query activation', async () => {
+    const $el = ESLToggleable.create();
+    const showSpy = jest.spyOn($el, 'show');
+    getMatchMediaMock(TEST_MQ).set(false);
+    $el.setAttribute(ESLOpenState.is, TEST_MQ);
+    document.body.append($el);
+    await twoTicks();
+    expect(showSpy).not.toHaveBeenCalledWith(expect.objectContaining({initiator: ESLOpenState.is}));
+
+    getMatchMediaMock(TEST_MQ).set(true);
+    expect(showSpy).toHaveBeenCalledWith(expect.objectContaining({initiator: ESLOpenState.is}));
+  });
+
+  test('ESLOpenState calls ESLTogleable\'s hide on media query deactivation', async () => {
+    const $el = ESLToggleable.create();
+    const hideSpy = jest.spyOn($el, 'hide');
+    getMatchMediaMock(TEST_MQ).set(true);
+    $el.setAttribute('open', '');
+    $el.setAttribute(ESLOpenState.is, TEST_MQ);
+    document.body.append($el);
+    await twoTicks();
+    expect(hideSpy).not.toHaveBeenCalledWith(expect.objectContaining({initiator: ESLOpenState.is}));
+
+    getMatchMediaMock(TEST_MQ).set(false);
+    expect(hideSpy).toHaveBeenCalledWith(expect.objectContaining({initiator: ESLOpenState.is}));
   });
 });


### PR DESCRIPTION


Closes: [epic(esl-open-state): create axillary mixin to produce show/open actions on marked esl-toggleable instance #2103](https://github.com/exadel-inc/esl/issues/2103)