### PR TITLE
fix(esl-event-listener): `ESLEventUtils.descriptors` api notes correction

### DIFF
--- a/src/modules/esl-event-listener/README.md
+++ b/src/modules/esl-event-listener/README.md
@@ -309,25 +309,44 @@ Predicate to check if the passed argument is a type of `ESLListenerDescriptorFn 
 ESLEventUtils.isEventDescriptor(obj: any): obj is ESLListenerDescriptorFn;
 ```
 
-<a name="-esleventutilsgetautodescriptors"></a>
+<a name="-esleventutilsdescriptors"></a>
 
-### ⚡ `ESLEventUtils.getAutoDescriptors`
+### ⚡ `ESLEventUtils.descriptors`
 
 Gathers auto-subscribable (collectable) descriptors from the passed object.
 
+Note: the method is going to be updated in the next release to support the `criteria` parameter. 
+It's strongly recommended to pass criteria `{auto: true}` already to have no issues with the future update.
+
 ```typescript
+// Note: deprecated in current version due to the future update
 ESLEventUtils.descriptors(host?: any): ESLListenerDescriptorFn[]
+
+// Recommended usage
+ESLEventUtils.descriptors(host?: any, criteria: {auto: true}): ESLListenerDescriptorFn[]
 ```
 
 **Parameters**:
 
 - `host` - object to get auto-collectable descriptors from;
 
-<a name="-esleventutilsdescriptors"></a>
 
-### ⚡ `ESLEventUtils.descriptors`
+<a name="-esleventutilsgetautodescriptors"></a>
 
-Deprecated alias for `ESLEventUtils.getAutoDescriptors`
+### ⚡ `ESLEventUtils.getAutoDescriptors`
+
+Gathers auto-subscribable (collectable) descriptors from the passed object.
+
+Deprecated: prefer using `ESLEventUtils.descriptors` with the `{auto: true}` criteria. As the `getAutoDescriptors` method is going to be removed in 6th release.
+
+```typescript
+ESLEventUtils.getAutoDescriptors(host?: any): ESLListenerDescriptorFn[]
+```
+
+**Parameters**:
+
+- `host` - object to get auto-collectable descriptors from;
+
 
 <a name="-esleventutilsinitdescriptor"></a>
 

--- a/src/modules/esl-event-listener/core/api.ts
+++ b/src/modules/esl-event-listener/core/api.ts
@@ -22,10 +22,22 @@ export class ESLEventUtils {
    */
   public static dispatch = dispatchCustomEvent;
 
-  /** @deprecated alias for {@link getAutoDescriptors} */
-  public static descriptors = getAutoDescriptors;
+  /**
+   * @deprecated going to be updated in 5.0.0 to return all descriptors,
+   * it's recommended to change to `descriptors(host, {auto: true})` method, to have compatibility with future versions
+   */
+  public static descriptors(host: object): ESLListenerDescriptorFn[];
+  /** Gets auto {@link ESLListenerDescriptorFn}s of the passed object */
+  public static descriptors(host: object, criteria: {auto: true}): ESLListenerDescriptorFn[];
+  public static descriptors(host: object): ESLListenerDescriptorFn[]  {
+    return getAutoDescriptors(host);
+  }
 
-  /** Gets {@link ESLListenerDescriptorFn}s of the passed object */
+  /**
+   * Gets auto {@link ESLListenerDescriptorFn}s of the passed object
+   *
+   * @deprecated alias for `descriptors(host, {auto: true})`
+   */
   public static getAutoDescriptors = getAutoDescriptors;
 
   /**


### PR DESCRIPTION
Note: `ESLEventUtils.descriptors` is going to be reintroduced in 5.0.0
NOTE: It is a proper (not deprecated) way to use `ESLEventUtils.descriptors(host, {auto: true})` instead `ESLEventUtils.getAutoDescriptors`

See related 5.0.0 update ->  https://github.com/exadel-inc/esl/pull/2413