### PR TITLE
feat(esl-media): add ability to provide video initial position (start time)

### DIFF
--- a/site/views/examples/embedded-media.njk
+++ b/site/views/examples/embedded-media.njk
@@ -210,6 +210,7 @@ aside:
       <option value="manual">Manual</option>
       <option value="auto">Auto</option>
     </uip-select-setting>
+    <uip-text-setting label="Start time:" attribute="start-time"></uip-text-setting>
     <uip-bool-setting label="Muted" attribute="muted"></uip-bool-setting>
     <uip-bool-setting label="Autoplay" attribute="autoplay"></uip-bool-setting>
   </uip-settings>

--- a/src/modules/esl-media/README.md
+++ b/src/modules/esl-media/README.md
@@ -85,7 +85,7 @@ using a single tag as well as work with external providers using simple native-l
  - `load-condition-class-target` (optional) - [ESLTraversingQuery](../esl-traversing-query/README.md) to define a target for `load-condition-class`
 
  - `start-time` - attribute that allows a user to start viewing a video from a specific time offset. The value is simple time in seconds. By default, it is undefined which means to start from the beginning.
-*(note: that feature doesn't work for Abstract Iframe provider, also doesn't works for HTMLAudio and HTMLVideo providers in case when Web-server when hosted resource doesn't supports ['Accept-Ranges' HTTP response marker](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Ranges))*
+*(note: that feature doesn't work for Abstract Iframe provider, also doesn't work for HTMLAudio and HTMLVideo providers in case when Web-server when hosted resource doesn't support ['Accept-Ranges' HTTP response marker](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Ranges))*
 
 #### Deprecated attributes (going to be removed in the next major release):
  - `load-cls-accepted` (optional) - class to add when the media is loaded and accepted by the load condition. Use `load-condition-class` instead.

--- a/src/modules/esl-media/README.md
+++ b/src/modules/esl-media/README.md
@@ -84,6 +84,9 @@ using a single tag as well as work with external providers using simple native-l
     Independent of the lazy state, use `ready-class` if you are interested in the final state of component.
  - `load-condition-class-target` (optional) - [ESLTraversingQuery](../esl-traversing-query/README.md) to define a target for `load-condition-class`
 
+ - `start-time` - attribute that allows a user to start viewing a video from a specific time offset. The value is simple time in seconds. By default, it is undefined which means to start from the beginning.
+*(note: that feature doesn't work for Abstract Iframe provider, also doesn't works for HTMLAudio and HTMLVideo providers in case when Web-server when hosted resource doesn't supports ['Accept-Ranges' HTTP response marker](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Ranges))*
+
 #### Deprecated attributes (going to be removed in the next major release):
  - `load-cls-accepted` (optional) - class to add when the media is loaded and accepted by the load condition. Use `load-condition-class` instead.
  - `load-cls-declined` (optional) - class to add when the media is loaded and rejected by the load condition. Use `load-condition-class` with inverted syntax (`!class`) instead.

--- a/src/modules/esl-media/core/esl-media-provider.ts
+++ b/src/modules/esl-media/core/esl-media-provider.ts
@@ -22,6 +22,7 @@ export interface MediaProviderConfig {
   title: string;
   preload?: 'none' | 'metadata' | 'auto' | '';
   playsinline?: boolean;
+  startTime?: number;
 }
 
 export type ProviderType = (new(component: ESLMedia, config: MediaProviderConfig) => BaseProvider) & typeof BaseProvider;
@@ -39,8 +40,8 @@ export abstract class BaseProvider {
     return null;
   }
   static parseConfig(component: ESLMedia): MediaProviderConfig {
-    const {loop, muted, controls, autoplay, title, preload, playsinline, mediaId, mediaSrc} = component;
-    const config = {loop, muted, controls, autoplay, title, preload, playsinline};
+    const {loop, muted, controls, autoplay, title, preload, playsinline, mediaId, mediaSrc, startTime} = component;
+    const config = {loop, muted, controls, autoplay, title, preload, playsinline, startTime};
     if (mediaId) Object.assign(config, {mediaId});
     if (mediaSrc) Object.assign(config, {mediaSrc});
     return config;

--- a/src/modules/esl-media/core/esl-media.ts
+++ b/src/modules/esl-media/core/esl-media.ts
@@ -97,6 +97,8 @@ export class ESLMedia extends ESLBaseElement {
   @boolAttr() public playsinline: boolean;
   /** Allows play resource only in viewport area */
   @boolAttr() public playInViewport: boolean;
+  /** Allows to start viewing a resource from a specific time offset. */
+  @attr() public startTime: number;
 
   /** Preload resource */
   @attr({defaultValue: 'auto'}) public preload: 'none' | 'metadata' | 'auto' | '';

--- a/src/modules/esl-media/core/esl-media.ts
+++ b/src/modules/esl-media/core/esl-media.ts
@@ -98,7 +98,7 @@ export class ESLMedia extends ESLBaseElement {
   /** Allows play resource only in viewport area */
   @boolAttr() public playInViewport: boolean;
   /** Allows to start viewing a resource from a specific time offset. */
-  @attr() public startTime: number;
+  @attr({parser: parseInt}) public startTime: number;
 
   /** Preload resource */
   @attr({defaultValue: 'auto'}) public preload: 'none' | 'metadata' | 'auto' | '';

--- a/src/modules/esl-media/providers/brightcove-provider.ts
+++ b/src/modules/esl-media/providers/brightcove-provider.ts
@@ -63,6 +63,7 @@ export class BrightcoveProvider extends BaseProvider {
     el.toggleAttribute('playsinline', this.config.playsinline);
     this._account.playerId && el.setAttribute('data-player', this._account.playerId);
     this._account.accountId && el.setAttribute('data-account', this._account.accountId);
+    this.config.startTime && el.setAttribute('data-start-time', `${this.config.startTime}`);
     return el;
   }
 

--- a/src/modules/esl-media/providers/html5/audio-provider.ts
+++ b/src/modules/esl-media/providers/html5/audio-provider.ts
@@ -14,7 +14,7 @@ export class AudioProvider extends HTMLMediaProvider {
 
   protected createElement(): HTMLAudioElement {
     const el = document.createElement('audio');
-    el.src = this.config.mediaSrc || '';
+    el.src = this.mediaSrc || '';
     return el;
   }
 

--- a/src/modules/esl-media/providers/html5/audio-provider.ts
+++ b/src/modules/esl-media/providers/html5/audio-provider.ts
@@ -14,7 +14,7 @@ export class AudioProvider extends HTMLMediaProvider {
 
   protected createElement(): HTMLAudioElement {
     const el = document.createElement('audio');
-    el.src = this.mediaSrc || '';
+    el.src = this.src;
     return el;
   }
 

--- a/src/modules/esl-media/providers/html5/media-provider.ts
+++ b/src/modules/esl-media/providers/html5/media-provider.ts
@@ -61,6 +61,10 @@ export abstract class HTMLMediaProvider extends BaseProvider {
     return Promise.resolve();
   }
 
+  protected get mediaSrc(): string {
+    return `${this.config.mediaSrc}${this.config.startTime ? `#t=${this.config.startTime}` : ''}`;
+  }
+
   public get state(): PlayerStates {
     if (!this._el) return PlayerStates.UNINITIALIZED;
     if (this._el.ended) return PlayerStates.ENDED;

--- a/src/modules/esl-media/providers/html5/media-provider.ts
+++ b/src/modules/esl-media/providers/html5/media-provider.ts
@@ -61,7 +61,7 @@ export abstract class HTMLMediaProvider extends BaseProvider {
     return Promise.resolve();
   }
 
-  protected get mediaSrc(): string {
+  protected get src(): string {
     return `${this.config.mediaSrc}${this.config.startTime ? `#t=${this.config.startTime}` : ''}`;
   }
 

--- a/src/modules/esl-media/providers/html5/video-provider.ts
+++ b/src/modules/esl-media/providers/html5/video-provider.ts
@@ -14,7 +14,7 @@ export class VideoProvider extends HTMLMediaProvider {
 
   protected createElement(): HTMLVideoElement {
     const el = document.createElement('video');
-    el.src = this.config.mediaSrc || '';
+    el.src = this.mediaSrc || '';
     return el;
   }
 

--- a/src/modules/esl-media/providers/html5/video-provider.ts
+++ b/src/modules/esl-media/providers/html5/video-provider.ts
@@ -14,7 +14,7 @@ export class VideoProvider extends HTMLMediaProvider {
 
   protected createElement(): HTMLVideoElement {
     const el = document.createElement('video');
-    el.src = this.mediaSrc || '';
+    el.src = this.src;
     return el;
   }
 

--- a/src/modules/esl-media/providers/youtube-provider.ts
+++ b/src/modules/esl-media/providers/youtube-provider.ts
@@ -166,7 +166,7 @@ export class YouTubeProvider extends BaseProvider {
   }
 
   public seekTo(pos: number): void {
-    this._api.seekTo(pos, false);
+    this._api.seekTo(pos, true);
   }
 
   public play(): void {

--- a/src/modules/esl-media/providers/youtube-provider.ts
+++ b/src/modules/esl-media/providers/youtube-provider.ts
@@ -59,7 +59,8 @@ export class YouTubeProvider extends BaseProvider {
       controls: Number(cfg.controls),
       playsinline: Number(cfg.playsinline),
       disablekb: Number(!cfg.controls), // TODO: criteria
-      autohide: Number(!cfg.controls) // TODO: criteria
+      autohide: Number(!cfg.controls), // TODO: criteria
+      start: cfg.startTime
     };
   }
 


### PR DESCRIPTION
Closes: #2414 #2415 

- fixed "seekTo leads to no proper behaviour when youtube video is not ready"
- added "ability to provide video initial position (start time)"