### PR TITLE
chore(site): fix `unhandled in promise` error while site watch process

### DIFF
--- a/site/.eleventy.js
+++ b/site/.eleventy.js
@@ -30,6 +30,7 @@ module.exports = (config) => {
 
   config.setServerOptions({
     port: process.env.PORT || 3005,
+    domDiff: false, // Disabled until https://github.com/11ty/eleventy-dev-server/issues/77 is fixed
     watch: [
       'dist/bundles/*.js',
       'dist/bundles/*.css'


### PR DESCRIPTION
Temporary fix until `@11ty/eleventy-dev-server` update
See: https://github.com/11ty/eleventy-dev-server/issues/77 