### PR TITLE
fix(esl-utils): debounced promise return (POC)

### DIFF
--- a/src/modules/esl-utils/async/test/debounce.test.ts
+++ b/src/modules/esl-utils/async/test/debounce.test.ts
@@ -8,13 +8,12 @@ describe('async/debounce', () => {
     const fn = jest.fn();
     const debounced = debounce(fn, 50);
 
-    expect(debounced()).toBeUndefined();
     debounced();
     jest.advanceTimersByTime(25);
-    expect(debounced()).toBeUndefined();
     expect(fn).toBeCalledTimes(0);
     jest.advanceTimersByTime(50);
     expect(fn).toBeCalledTimes(1);
+    expect(debounced()).resolves.toBeUndefined();
   });
 
   test('call context', () => {


### PR DESCRIPTION
Closes: #1954 
Request was to handle the following code
```
  class Test {
    @decorate(debounce, 100) // TS: type are incompatible
    protected async update(): Promise<void> {
       // ... await
    }
  }
```
In order to do so, debouncedSubject now needs to return the promise