### PR TITLE
refactor(esl-media-query): deprecate `ESLMediaRuleList.parse`

### DIFF
--- a/src/modules/esl-media-query/README.md
+++ b/src/modules/esl-media-query/README.md
@@ -209,6 +209,7 @@ ESLMediaRuleList.parse('@XS => {option: 1} | @+SM => {option: 2}', evaluate); //
 ESLMediaRuleList.parseTuple('@xs|@sm|@md|@lg|@xl', '1|2|3|4|5') // String payload example
 ESLMediaRuleList.parseTuple('@xs|@sm|@md|@lg|@xl', '1|2|3|4|5',  Number) // Numeric payload sample
 ```
+**Note**: Method `ESLMediaRuleList.parse` is deprecated, and will be reintroduced in ESL v5.0.0 with a different signature. For now use `ESLMediaRuleList.parseTuple` or `ESLMediaRuleList.parseQuery` instead.
 
 #### ESLMediaRuleList API
 

--- a/src/modules/esl-media-query/core/esl-media-rule-list.ts
+++ b/src/modules/esl-media-query/core/esl-media-rule-list.ts
@@ -35,6 +35,8 @@ export class ESLMediaRuleList<T = any> extends SyntheticEventTarget {
   public static OBJECT_PARSER = <U = any>(val: string): U | undefined => evaluate(val);
 
   /**
+   * @deprecated Method will be reintroduced in v5.0.0 with a different signature. For now use ESLMediaRuleList.parseQuery instead
+   *
    * Creates `ESLMediaRuleList` from string query representation
    * Expect serialized {@link ESLMediaRule}s separated by '|'
    * Uses exact strings as rule list values
@@ -43,6 +45,8 @@ export class ESLMediaRuleList<T = any> extends SyntheticEventTarget {
    */
   public static parse(query: string): ESLMediaRuleList<string>;
   /**
+   * @deprecated Method will be reintroduced in v5.0.0 with a different signature. For now use ESLMediaRuleList.parseQuery instead
+   *
    * Creates `ESLMediaRuleList` from string query representation.
    * Expect serialized {@link ESLMediaRule}s separated by '|'
    *
@@ -51,6 +55,8 @@ export class ESLMediaRuleList<T = any> extends SyntheticEventTarget {
    */
   public static parse<U>(query: string, parser: RulePayloadParser<U>): ESLMediaRuleList<U>;
   /**
+   * @deprecated Method will be reintroduced in v5.0.0 with a different signature. For now use ESLMediaRuleList.parseTuple instead
+
    * Creates `ESLMediaRuleList` from two strings with conditions and values sequences
    *
    * @param mask - media conditions tuple string (uses '|' as separator)
@@ -63,6 +69,8 @@ export class ESLMediaRuleList<T = any> extends SyntheticEventTarget {
    */
   public static parse(mask: string, values: string): ESLMediaRuleList<string>;
   /**
+   * @deprecated Method will be reintroduced in v5.0.0 with a different signature. For now use ESLMediaRuleList.parseTuple instead
+   *
    * Creates `ESLMediaRuleList` from two strings with conditions and values sequences
    *
    * @param mask - media conditions tuple string (uses '|' as separator)


### PR DESCRIPTION
Relates to: #2377 