### PR TITLE
feat(esl-base-element): check if element is in the DOM on connected callback (POC)

### DIFF
--- a/site/views/draft/disconnected-callback.njk
+++ b/site/views/draft/disconnected-callback.njk
@@ -1,0 +1,22 @@
+---
+layout: empty
+title: Duplicated disconnected callback causing falsy duplicate connected callback
+name: Disconnected callback
+tags: draft
+---
+
+<section class="row">
+  <div class="col-12">
+      <script>
+        const select = document.createElement('esl-select');
+        select.innerHTML = `<select esl-select-target/>`
+        document.body.appendChild(select);
+      </script>
+  </div>
+
+  <div class="btn-group btn-group-centered" style="width: 100%">
+    <button class="btn btn-sec-blue" onclick="setTimeout(() => document.body.appendChild(document.querySelector('esl-select')), 20)">
+      Click me to cause duplicate reinit!
+    </button>
+  </div>
+</section>

--- a/src/modules/esl-base-element/core/esl-base-element.ts
+++ b/src/modules/esl-base-element/core/esl-base-element.ts
@@ -43,7 +43,10 @@ export abstract class ESLBaseElement extends HTMLElement implements ESLBaseCompo
   protected connectedCallback(): void {
     this._connected = true;
     this.classList.add(this.baseTagName);
-
+    if (!this.isConnected) {
+      console.info('[ESL]: Element is not connected to the DOM', this);
+      return;
+    }
     ESLEventUtils.subscribe(this);
   }
   protected disconnectedCallback(): void {


### PR DESCRIPTION
Recently we stumbled upon the following issue: _"[ESL]: No targets found for event listener"_

Upon investigation it was discovered that issue was appearing when multiple nested custom elements were re-appended to the DOM, with root element having logic that involves removal of the nested element from a child list, later causing duplicate connected callback and disconnected callback triggering, even though element wasn't technically appended to a DOM yet.

My guess that it might be that although element removal process is synchronous, it cannot remove element second time without re-appending it first.