### PR TITLE
Revert "chore(deps): bump puppeteer from 22.15.0 to 23.0.1"

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -19,7 +19,7 @@
     "@types/puppeteer": "^7.0.4",
     "jest-image-snapshot": "^6.4.0",
     "jest-puppeteer": "^10.0.1",
-    "puppeteer": "^23.0.1",
+    "puppeteer": "^22.15.0",
     "stucumber": "^0.19.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "@types/puppeteer": "^7.0.4",
         "jest-image-snapshot": "^6.4.0",
         "jest-puppeteer": "^10.0.1",
-        "puppeteer": "^23.0.1",
+        "puppeteer": "^22.15.0",
         "stucumber": "^0.19.0"
       }
     },
@@ -5444,9 +5444,9 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.6.4.tgz",
-      "integrity": "sha512-8zoq6ogmhQQkAKZVKO2ObFTl4uOkqoX1PlKQX3hZQ5E9cbUotcAb7h4pTNVAGGv8Z36PF3CtdOriEp/Rz82JqQ==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.6.3.tgz",
+      "integrity": "sha512-qXlsCmpCZJAnoTYI83Iu6EdYQpMYdVkCfq08KDh2pmlVqK5t5IA9mGs4/LwCwp4fqisSOMXZxP3HIh8w8aRn0A==",
       "dependencies": {
         "mitt": "3.0.1",
         "urlpattern-polyfill": "10.0.0",
@@ -17875,16 +17875,15 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-23.0.1.tgz",
-      "integrity": "sha512-i5P0MJcpLZ+lK66/B6TX9G347+Yh4D6b5KGyzaz8b7wYrNenN55GwRa1svKoZMUGjFHcmtQuniE7qZ8/k/YbQw==",
+      "version": "22.15.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.15.0.tgz",
+      "integrity": "sha512-XjCY1SiSEi1T7iSYuxS82ft85kwDJUS7wj1Z0eGVXKdtr5g4xnVcbjwxhq5xBnpK/E7x1VZZoJDxpjAOasHT4Q==",
       "hasInstallScript": true,
       "dependencies": {
         "@puppeteer/browsers": "2.3.0",
-        "chromium-bidi": "0.6.4",
         "cosmiconfig": "^9.0.0",
         "devtools-protocol": "0.0.1312386",
-        "puppeteer-core": "23.0.1"
+        "puppeteer-core": "22.15.0"
       },
       "bin": {
         "puppeteer": "lib/esm/puppeteer/node/cli.js"
@@ -17894,12 +17893,12 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.0.1.tgz",
-      "integrity": "sha512-gZYLcZUkWHZW1vvKEdOZuAB++3qY96Uh4b7B22PI0802omN4Ghrjt9H1r64NVt+AmnaZ/6Q+OW60S/Q7y+BZgQ==",
+      "version": "22.15.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.15.0.tgz",
+      "integrity": "sha512-cHArnywCiAAVXa3t4GGL2vttNxh7GqXtIYGym99egkNJ3oG//wL9LkvO4WE8W1TJe95t1F1ocu9X4xWaGsOKOA==",
       "dependencies": {
         "@puppeteer/browsers": "2.3.0",
-        "chromium-bidi": "0.6.4",
+        "chromium-bidi": "0.6.3",
         "debug": "^4.3.6",
         "devtools-protocol": "0.0.1312386",
         "ws": "^8.18.0"


### PR DESCRIPTION
Reverts exadel-inc/esl#2570

revert until jest-puppeteer will be compatible