### PR TITLE
test(e2e): handle sanpshot's size mismatch

### DIFF
--- a/e2e/setup/serializers/image-snapshot.matcher.ts
+++ b/e2e/setup/serializers/image-snapshot.matcher.ts
@@ -7,6 +7,13 @@ import type {SnapshotData} from './image-snapshot.pocessor';
 
 export type SnapshotMatcherOptions = pixelmatch.PixelmatchOptions;
 
+type ImagesCompareResult = {
+  reason: 'content';
+} | {
+  reason: 'error';
+  message: any;
+} | undefined;
+
 export class SnapshotMatcher {
   protected static readonly MIN_DIFF_THRESHOLD: number = 0.0001;
 
@@ -25,7 +32,7 @@ export class SnapshotMatcher {
   }
 
   public async match(): Promise<jest.CustomMatcherResult> {
-    const {current, previous, snapshotPath} = this.received;
+    const {current, previous, snapshotPath, diffPath} = this.received;
     if (!previous.buffer) {
       mkDir(path.dirname(snapshotPath));
       current.img.toFile(snapshotPath);
@@ -34,31 +41,31 @@ export class SnapshotMatcher {
 
     const diff = await this.compareImages();
     if (!diff) return this.getMatcherResult(true, `Image is the same as the snapshot: ${snapshotPath}`);
-    if (diff.reason === 'content') return this.getMatcherResult(false, `Image mismatch found: ${diff.path}`);
-    return this.getMatcherResult(false, `Error comparing snapshot to image ${snapshotPath}`);
+    if (diff.reason === 'content') return this.getMatcherResult(false, `Image mismatch found: ${diffPath}`);
+    return this.getMatcherResult(false, `Error comparing snapshot to image ${snapshotPath}\nMessage: ${diff.message}`);
   }
 
   protected getMatcherResult(pass: boolean, message: string): jest.CustomMatcherResult {
     return {pass, message: () => message};
   }
 
-  protected async compareImages(): Promise<{reason: 'content' | 'error', path?: string} | undefined> {
+  protected async compareImages(): Promise<ImagesCompareResult> {
     const {current, previous, diffPath} = this.received;
-    const prevImg = previous.buffer!;
-    const currImg = current.buffer;
+    const prevBuffer = previous.buffer!;
+    const currBuffer = current.buffer;
 
-    const {width, height} = prevImg.info;
+    const {width, height} = prevBuffer.info;
     const diffBuffer = Buffer.alloc(width * height * 4);
     try {
-      const numDiffPixel = pixelmatch(prevImg.data, currImg.data, diffBuffer, width, height, this.config);
+      const numDiffPixel = pixelmatch(prevBuffer.data, currBuffer.data, diffBuffer, width, height, this.config);
       if (numDiffPixel > width * height * SnapshotMatcher.MIN_DIFF_THRESHOLD) {
         const diffConfig = Object.assign({}, this.received, {diffBuffer});
         mkDir(path.dirname(diffPath));
         await (await DiffImageComposer.compose(diffConfig)).toFile(diffPath);
-        return {reason: 'content', path: diffPath};
+        return {reason: 'content'};
       }
     } catch (e) {
-      return {reason: 'error'};
+      return {reason: 'error', message: e};
     }
   }
 }

--- a/e2e/setup/serializers/image-snapshot.sharp.ts
+++ b/e2e/setup/serializers/image-snapshot.sharp.ts
@@ -38,6 +38,8 @@ export class SharpService {
       height: number,
       metadata: sharp.Metadata
     ): Promise<Buffer> => {
+      if (metadata.width === width && metadata.height === height) return image.toBuffer();
+
       const padX = Math.max(0, (width - metadata.width!) / 2);
       const padY = Math.max(0, (height - metadata.height!) / 2);
 


### PR DESCRIPTION
After test run of a new snapshot matcher implementation, it was discovered that reports became less informative.
The most important things are:
- Missing reports on when two snapshot have mismatching size
- Error messages are less informative