### PR TITLE
site: nav updates, 5.0.0 migration guide for blogs section

### DIFF
--- a/site/src/navigation/sidebar/sidebar-content.less
+++ b/site/src/navigation/sidebar/sidebar-content.less
@@ -61,7 +61,8 @@ esl-d-sidebar {
 
     height: 100%;
     margin-top: 0;
-    @media @md-lg {
+
+    @media @md-xl {
       margin-top: 30px;
     }
   }

--- a/site/src/navigation/sidebar/sidebar-content.less
+++ b/site/src/navigation/sidebar/sidebar-content.less
@@ -21,7 +21,6 @@ esl-d-sidebar {
     margin: 0 2px;
     padding: 0 8px;
     align-items: center;
-    margin-bottom: 20px;
 
     color: inherit;
     text-decoration: none;
@@ -39,13 +38,12 @@ esl-d-sidebar {
 
   .sidebar-title {
     flex: 1 0 auto;
-    padding-left: 2px;
+    padding-inline: 16px;
     overflow: hidden;
 
     font-size: 0.95rem;
     font-weight: 600;
     line-height: 20px;
-    text-align: center;
     text-transform: uppercase;
 
     opacity: 1;

--- a/site/src/navigation/sidebar/sidebar-seccondary-nav.less
+++ b/site/src/navigation/sidebar/sidebar-seccondary-nav.less
@@ -62,7 +62,7 @@ esl-d-sidebar {
     }
 
     .sidebar-nav-secondary-item {
-      padding-inline-start: calc(var(--padding-inline-start) + 25px);
+      padding-inline-start: calc(var(--padding-inline-start) + 30px);
     }
   }
 

--- a/site/src/navigation/sidebar/sidebar.less
+++ b/site/src/navigation/sidebar/sidebar.less
@@ -4,7 +4,7 @@ esl-d-sidebar {
   --esl-sidebar-width: 100vw;
   --esl-sidebar-width-closed: 72px;
   @media @sm-xl {
-    --esl-sidebar-width: 20rem;
+    --esl-sidebar-width: 21rem;
   }
 
   display: block;

--- a/site/views/_includes/navigation/sidebar-item.njk
+++ b/site/views/_includes/navigation/sidebar-item.njk
@@ -98,7 +98,7 @@
 {% endmacro %}
 
 {% macro badgeByTags(tags, isDraftCollection) %}
-  {# Tags chaecks ordered by priority, due to displaying single badge #}
+  {# Tags checks ordered by priority, due to displaying single badge #}
   {% if tags.includes('deprecated') %}
     <span class="badge badge-sidebar badge-img badge-deprecated" title="Deprecated component" aria-label="Deprecated component"></span>
   {% elif tags.includes('draft') and not isDraftCollection %}

--- a/site/views/_includes/navigation/sidebar-item.njk
+++ b/site/views/_includes/navigation/sidebar-item.njk
@@ -3,8 +3,7 @@
   {% set isPrimaryActive = functions.isActivePath(page.url, collection) %}
 
   {% if isDraftCollection and not env.isDev %}
-
-    {% set items = collections[collection] | filter('url', page.url) %}
+    {% set items = collections[collection] | filter('url', page.url) | tree %}
   {% else %}
     {% set items = collections[collection] | released | tree %}
   {% endif %}
@@ -40,12 +39,9 @@
   {% endif %}
 {% endmacro %}
 
-{% macro linkList(items, isDraftCollection, prepend = []) %}
+{% macro linkList(items, isDraftCollection) %}
   <ul class="sidebar-nav-secondary-list">
     <esl-a11y-group targets="::child(li)::find(.sidebar-nav-secondary-link)"></esl-a11y-group>
-    {% for item in prepend %}
-      {{ link(item, isDraftCollection) }}
-    {% endfor %}
     {% for item in items | sortBy('order', 'name') %}
       {% if item.children.length %}
         {{ subnavItem(item, isDraftCollection) }}
@@ -60,9 +56,6 @@
   {% set isActive = page.url === item.url %}
   {% set hasActive = functions.isActivePath(page.url, item.url) %}
   {% set isDraft = [].concat(item.data.tags).includes('draft') %}
-  {% set isNew = [].concat(item.data.tags).includes('new') %}
-  {% set isBeta = [].concat(item.data.tags).includes('beta') %}
-  {% set isDeprecated = [].concat(item.data.tags).includes('deprecated') %}
 
   <li class="sidebar-nav-secondary-item sidebar-nav-item-container {{ 'draft' if isDraft }}"
       {% if hasActive %}aria-selected="true"{% endif %}>
@@ -70,18 +63,7 @@
       <a class="sidebar-nav-secondary-link"
          {% if isActive %}aria-current="page"{% endif %} {% if isDraft %}rel="nofollow"{% endif %}
          href="{{ item.url | url }}">
-        {% if isNew %}
-          <sup class="badge badge-sup badge-success badge-sidebar">new</sup>
-        {% endif %}
-        {% if isBeta %}
-          <sup class="badge badge-sup badge-warning badge-sidebar">beta</sup>
-        {% endif %}
-        {% if isDraft %}
-          <sup class="badge badge-sup badge-danger badge-sidebar" {% if isDraftCollection %}hidden{% endif %}>draft</sup>
-        {% endif %}
-        {% if isDeprecated %}
-          <span class="badge badge-img badge-deprecated badge-sidebar" aria-label="Deprecated component" title="Deprecated component"></span>
-        {% endif %}
+        {{ badgeByTags(item.data.tags, isDraftCollection) }}
         {{ item.data.name }}
       </a>
       <esl-trigger class="sidebar-nav-item-trigger sidebar-nav-item-arrow"
@@ -103,28 +85,29 @@
 {% macro link(item, isDraftCollection) %}
   {% set isActive = page.url === item.url %}
   {% set isDraft = [].concat(item.data.tags).includes('draft') %}
-  {% set isNew = [].concat(item.data.tags).includes('new') %}
-  {% set isBeta = [].concat(item.data.tags).includes('beta') %}
-  {% set isDeprecated = [].concat(item.data.tags).includes('deprecated') %}
 
   <li class="sidebar-nav-secondary-item {{ 'active' if isActive }} {{ 'draft' if isDraft }}"
       {% if isActive %}aria-selected="true"{% endif %}>
     <a class="sidebar-nav-secondary-link"
        {% if isActive %}aria-current="page"{% endif %} {% if isDraft %}rel="nofollow"{% endif %}
        href="{{ item.url | url }}">
-      {% if isNew %}
-        <sup class="badge badge-sup badge-success badge-sidebar">new</sup>
-      {% endif %}
-      {% if isBeta %}
-        <sup class="badge badge-sup badge-warning badge-sidebar">beta</sup>
-      {% endif %}
-      {% if isDraft %}
-        <sup class="badge badge-sup badge-danger badge-sidebar" {% if isDraftCollection %}hidden{% endif %}>draft</sup>
-      {% endif %}
-      {% if isDeprecated %}
-        <span class="badge badge-img badge-deprecated badge-sidebar" aria-label="Deprecated component" title="Deprecated component"></span>
-      {% endif %}
+      {{ badgeByTags(item.data.tags, isDraftCollection) }}
       {{ item.data.name }}
     </a>
   </li>
+{% endmacro %}
+
+{% macro badgeByTags(tags, isDraftCollection) %}
+  {# Tags chaecks ordered by priority, due to displaying single badge #}
+  {% if tags.includes('deprecated') %}
+    <span class="badge badge-sidebar badge-img badge-deprecated" title="Deprecated component" aria-label="Deprecated component"></span>
+  {% elif tags.includes('draft') and not isDraftCollection %}
+    <sup class="badge badge-sidebar badge-sup badge-danger" title="Just a draft version of the page">draft</sup>
+  {% elif tags.includes('beta') %}
+    <sup class="badge badge-sidebar badge-sup badge-warning" title="Beta version (could change in a minor update)">beta</sup>
+  {% elif tags.includes('updated') %}
+    <sup class="badge badge-sidebar badge-sup badge-success" title="Updated" aria-label="Updated">upd*</sup>
+  {% elif tags.includes('new') %}
+    <sup class="badge badge-sidebar badge-sup badge-success" title="New article and functionality">new</sup>
+  {% endif %}
 {% endmacro %}

--- a/site/views/_layouts/content.njk
+++ b/site/views/_layouts/content.njk
@@ -6,7 +6,8 @@
   {% include 'navigation/sidebar.njk' %}
 
   <main class="esl-scrollable-content">
-    <div class="content {{ containerCls or 'container' }} {{ 'container-aside' if aside }}">
+    {% set isMarkdownSource = page.templateSyntax.includes('md') %}
+    <div class="content {{ containerCls or 'container' }} {{ 'container-aside' if aside }} {{ 'markdown-container' if isMarkdownSource }}">
       {% if title %}
         <h1 class="page-title">
           {% if collectionIcon %}{% include "static/assets/" + collectionIcon %}{% endif %}

--- a/site/views/blogs/ESL v5.0.0 Migartion Guide.md
+++ b/site/views/blogs/ESL v5.0.0 Migartion Guide.md
@@ -1,0 +1,72 @@
+---
+layout: content
+name: ESL v5.0.0 Migartion Guide
+title: Migrating from ESL v4.*.* to ESL v5.0.0
+tags: [news, blogs, draft]
+date: 2024-11-31
+---
+
+The ESL version 5.0.0 have just been released and it comes with a lot of new features and improvements. 
+This guide will help you to migrate your existing ESL v4.\*.* project to ESL v5.0.0.
+
+---
+
+## Preparation
+We recommend you to consider using ESL ESLint plugin to check your codebase for ESL v5.0.0 compatibility.
+It will help you to find and fix most of the issues before you start the migration process.
+The points not marked with `🔧` in the breaking changes section are covered by the ESLint plugin checks and could be fixed automatically.
+
+---
+
+## Breaking Changes
+
+- ### Browser Support
+  ESL v5.0.0 no longer supports IE11 and ES5 target. 
+  ESL UI site renderer and ESL polyfills no longer support Edge old versions and ES6 polyfils.
+  In case by some reason you still need to support IE11 or ES5 target you should use proper transpilation and polyfilling tools on your side.
+
+- ### ESL Core / ESL Utils
+  - #### Direct imports changes
+    - 🔧 `prop`, `attr`, `boolAttr`, `jsonAttr`, `listen` no longer available in `esl-base-element` and `esl-mixin-element` exports,
+    to use them you should import them from `esl-utils/decorators` directly or from the library root.
+  - #### ESL Utils API Changes
+    - `Rect` utility object is now immutable, so you can't change its properties directly. 
+    If you modify the `Rect` object troug builtin methods, you will get a new object with the updated properties.
+  - #### ESL Utils Retired Functianality
+    - `DeviceDetector.TOUCH_EVENTS` and `TOUCH_EVENTS` are retired from the `device-detector` module.
+    - Note that the `DeviceDetector` class is now deprecated. Use direct checks instead.
+    - `createZIndexIframe` and `is-fixes` module are no longer available due to drop of IE11 support.
+    - `RTLUtils` and `TraversingUtils` are retired. Use separate methods instead.
+    - 🔧 `TraversingQuery` is retired as alias. Use `ESLTraversingQuery` instead.
+    - 🔧 `deepCompare` is retired as alias. Use `isEqual` instead.
+    - 🔧 `generateUId` is retired as alias. Use `randUID` instead.
+    - 🔧 `EventUtils` is retired as alias. Use `ESLEventUtils` instead.
+  - #### `SynteticEventTarget` API Changes
+    - `addListener` and `removeListener` shorthand are no longer supported. Use `addEventListener` and `removeEventListener` instead.
+    - `dispatchEvent` no longer accepts the target argument. 
+      You can override the target using `overrideEvent` method from `esl-utils/dom/events`.
+    - 🔧 `ESLEventUtils.descriptors` alias of `ESLEventUtils.getAutoDescriptors` is no longer supported, use full method name instead.
+  - #### ESL Media Query
+    - ESL Media Query consume functionality of `SynteticEventTarget` so `addListener` and `removeListener` shorthand are no longer supported. 
+    Use `addEventListener` and `removeEventListener` instead.
+
+- ### ESL Togglables and Triggers
+  - #### ESL Togglables API Changes
+    - `ToggleableActionParams` alias of `ESLToggleableActionParams` is no longer supported.
+    - `onBeforeShow` and `onBeforeHide` have retired. The constraint now inside `shouldShow`/`shouldHide` methods. 
+      Note that `activator` property change now is the part of main togglable flow.
+    - `this.open` of Toggleables does not updating util super.onShow/super.onHide called. 
+      Make sure you update `this.open` synchronously or manually notify consumers in case the super call of `onShow/onHide` should be postponed.
+  - #### ESL Triggers API Changes
+    - `ESLTrigger` does not have target defined to `::next` by default. You should always define the target explicitly.
+  - #### ESL Panel and Panel Group
+    - `fallback-duration` is no longer in the JSX shape of `ESLPanel` and `ESLPanelGroup`.
+
+- ### ESL Image
+  - CSS aspect-ratio styles are no longer distributed with ESL Image. 
+    You should define them in your project styles or use a separate package for that.
+  - Note that ESL Image is now deprecated. Consider using native Image element with optional help from `esl-image-utils` module. 
+
+- ### ESL Media
+  - `load-cls-target`, `load-cls-accepted` and `load-cls-declined` use `load-condition-class` and `load-condition-class-target` instead.
+  - `disabled` marker no longer supported use `lazy="manual"` instead (the `force` option of `play` method works the same way with new lazy option).

--- a/site/views/blogs/ESL v5.0.0 Migartion Guide.md
+++ b/site/views/blogs/ESL v5.0.0 Migartion Guide.md
@@ -1,12 +1,12 @@
 ---
 layout: content
-name: ESL v5.0.0 Migartion Guide
+name: ESL v5.0.0 Migration Guide
 title: Migrating from ESL v4.*.* to ESL v5.0.0
 tags: [news, blogs, draft]
-date: 2024-11-31
+date: 2024-10-31
 ---
 
-The ESL version 5.0.0 have just been released and it comes with a lot of new features and improvements. 
+The ESL version 5.0.0 has just been released and it comes with a lot of new features and improvements. 
 This guide will help you to migrate your existing ESL v4.\*.* project to ESL v5.0.0.
 
 ---
@@ -23,16 +23,16 @@ The points not marked with `🔧` in the breaking changes section are covered by
 - ### Browser Support
   ESL v5.0.0 no longer supports IE11 and ES5 target. 
   ESL UI site renderer and ESL polyfills no longer support Edge old versions and ES6 polyfils.
-  In case by some reason you still need to support IE11 or ES5 target you should use proper transpilation and polyfilling tools on your side.
+  In case for some reason you still need to support IE11 or ES5 target you should use proper transpilation and polyfilling tools on your side.
 
 - ### ESL Core / ESL Utils
   - #### Direct imports changes
-    - 🔧 `prop`, `attr`, `boolAttr`, `jsonAttr`, `listen` no longer available in `esl-base-element` and `esl-mixin-element` exports,
+    - 🔧 `prop`, `attr`, `boolAttr`, `jsonAttr`, `listen` are no longer available in `esl-base-element` and `esl-mixin-element` exports,
     to use them you should import them from `esl-utils/decorators` directly or from the library root.
   - #### ESL Utils API Changes
     - `Rect` utility object is now immutable, so you can't change its properties directly. 
-    If you modify the `Rect` object troug builtin methods, you will get a new object with the updated properties.
-  - #### ESL Utils Retired Functianality
+    If you modify the `Rect` object trough builtin methods, you will get a new object with the updated properties.
+  - #### ESL Utils Retired Functionality
     - `DeviceDetector.TOUCH_EVENTS` and `TOUCH_EVENTS` are retired from the `device-detector` module.
     - Note that the `DeviceDetector` class is now deprecated. Use direct checks instead.
     - `createZIndexIframe` and `is-fixes` module are no longer available due to drop of IE11 support.
@@ -50,17 +50,20 @@ The points not marked with `🔧` in the breaking changes section are covered by
     - ESL Media Query consume functionality of `SynteticEventTarget` so `addListener` and `removeListener` shorthand are no longer supported. 
     Use `addEventListener` and `removeEventListener` instead.
 
-- ### ESL Togglables and Triggers
-  - #### ESL Togglables API Changes
+- ### ESL Toggleables and Triggers
+  - #### ESL Toggleables API Changes
     - `ToggleableActionParams` alias of `ESLToggleableActionParams` is no longer supported.
     - `onBeforeShow` and `onBeforeHide` have retired. The constraint now inside `shouldShow`/`shouldHide` methods. 
-      Note that `activator` property change now is the part of main togglable flow.
-    - `this.open` of Toggleables does not updating util super.onShow/super.onHide called. 
+      Note that `activator` property change now is the part of main toggleable flow.
+    - `this.open` of Toggleables doesn't update until super.onShow/super.onHide is called. 
       Make sure you update `this.open` synchronously or manually notify consumers in case the super call of `onShow/onHide` should be postponed.
   - #### ESL Triggers API Changes
     - `ESLTrigger` does not have target defined to `::next` by default. You should always define the target explicitly.
   - #### ESL Panel and Panel Group
     - `fallback-duration` is no longer in the JSX shape of `ESLPanel` and `ESLPanelGroup`.
+
+- ### ESL Footnotes
+  - `ESLNote` now based on `ESLBaseTrigger` so active marker now called `active` instead of `tooltip-shown`.
 
 - ### ESL Image
   - CSS aspect-ratio styles are no longer distributed with ESL Image. 
@@ -69,4 +72,4 @@ The points not marked with `🔧` in the breaking changes section are covered by
 
 - ### ESL Media
   - `load-cls-target`, `load-cls-accepted` and `load-cls-declined` use `load-condition-class` and `load-condition-class-target` instead.
-  - `disabled` marker no longer supported use `lazy="manual"` instead (the `force` option of `play` method works the same way with new lazy option).
+  - `disabled` marker is no longer supported, use `lazy="manual"` instead (the `force` option of `play` method works the same way with the new lazy option).

--- a/site/views/core/esl-event-listener/index.njk
+++ b/site/views/core/esl-event-listener/index.njk
@@ -3,7 +3,7 @@ layout: content
 title: ESL Event Listeners
 seoTitle: Built-in ESL EventListeners
 name: ESL Event Listeners
-tags: [core]
+tags: [core, updated]
 order: 2
 aside:
   source: src/modules/esl-event-listener


### PR DESCRIPTION
A screen of nav panel
![image](https://github.com/user-attachments/assets/cce363a1-e700-4fe2-a4b8-9350cab4c18e)

Blogs screen:
![image](https://github.com/user-attachments/assets/eecfef53-bd6e-4147-a91a-7b0920c26ce0)
