### PR TITLE
feat(esl-utils): `safeContains` traverse utility

### DIFF
--- a/src/modules/esl-utils/dom/traversing.ts
+++ b/src/modules/esl-utils/dom/traversing.ts
@@ -20,7 +20,8 @@ export function isRelativeNode(nodeA: Node | null | undefined, nodeB: null | und
 /** Checks that `nodeA` and `nodeB` are from the same tree path */
 export function isRelativeNode(nodeA: Node | null | undefined, nodeB: Node | null | undefined): boolean;
 export function isRelativeNode(nodeA: Node | null | undefined, nodeB: Node | null | undefined): boolean {
-  return isSafeContains(nodeA, nodeB) || isSafeContains(nodeB, nodeA);
+  if (!isElement(nodeA) || !isElement(nodeB)) return false;
+  return nodeA.contains(nodeB) || nodeB.contains(nodeA);
 }
 
 type IteratorFn = (el: Element) => Element | null;

--- a/src/modules/esl-utils/dom/traversing.ts
+++ b/src/modules/esl-utils/dom/traversing.ts
@@ -1,3 +1,4 @@
+import {isElement} from './api';
 import type {Predicate} from '../misc/functions';
 
 /** Checks if element matches passed selector or exact predicate function */
@@ -7,6 +8,11 @@ export const isMatches = (el: Element, matcher?: string | ((el: Element) => bool
   return typeof matcher === 'undefined';
 };
 
+/** Safely checks if the target element is within the container element */
+export const isSafeContains = (container: Node | null | undefined, element: Node | null | undefined): boolean => {
+  return isElement(element) && isElement(container) && container.contains(element);
+};
+
 /** Checks that `nodeA` and `nodeB` are from the same tree path */
 export function isRelativeNode(nodeA: null | undefined, nodeB: Node | null | undefined): false;
 /** Checks that `nodeA` and `nodeB` are from the same tree path */
@@ -14,7 +20,7 @@ export function isRelativeNode(nodeA: Node | null | undefined, nodeB: null | und
 /** Checks that `nodeA` and `nodeB` are from the same tree path */
 export function isRelativeNode(nodeA: Node | null | undefined, nodeB: Node | null | undefined): boolean;
 export function isRelativeNode(nodeA: Node | null | undefined, nodeB: Node | null | undefined): boolean {
-  return !!(nodeA && nodeB) && (nodeA.contains(nodeB) || nodeB.contains(nodeA));
+  return isSafeContains(nodeA, nodeB) || isSafeContains(nodeB, nodeA);
 }
 
 type IteratorFn = (el: Element) => Element | null;


### PR DESCRIPTION
Relates to: #2712

During the implementation of ticket #2712, it was discovered that the combination of checking if a node is an element and using element.contains is frequently needed. To streamline this, an `isSafeContains` utility was introduced.