### PR TITLE
fix(esl-media): detect youtube provider stopped state

### DIFF
--- a/src/modules/esl-media/providers/youtube-provider.ts
+++ b/src/modules/esl-media/providers/youtube-provider.ts
@@ -20,7 +20,7 @@ export class YouTubeProvider extends BaseProvider {
   protected override _el: HTMLDivElement | HTMLIFrameElement;
   protected _api: YT.Player;
 
-  protected lastPlayerState: null | number;
+  protected _lastPlayerState: PlayerStates = PlayerStates.UNINITIALIZED;
 
   static override parseUrl(url: string): Partial<MediaProviderConfig> | null {
     if (this.providerRegexp.test(url)) {
@@ -135,11 +135,11 @@ export class YouTubeProvider extends BaseProvider {
         }
         break;
       case PlayerStates.UNSTARTED:
-        if (this.lastPlayerState === PlayerStates.PLAYING || this.lastPlayerState === PlayerStates.PAUSED) this.component._onEnded();
+        if (this._lastPlayerState === PlayerStates.PLAYING || this._lastPlayerState === PlayerStates.PAUSED) this.component._onEnded();
         break;
     }
 
-    this.lastPlayerState = newState;
+    this._lastPlayerState = newState;
   }
 
   protected override onConfigChange(param: ProviderObservedParams, value: boolean): void {

--- a/src/modules/esl-media/providers/youtube-provider.ts
+++ b/src/modules/esl-media/providers/youtube-provider.ts
@@ -20,6 +20,8 @@ export class YouTubeProvider extends BaseProvider {
   protected override _el: HTMLDivElement | HTMLIFrameElement;
   protected _api: YT.Player;
 
+  protected lastPlayerState: null | number;
+
   static override parseUrl(url: string): Partial<MediaProviderConfig> | null {
     if (this.providerRegexp.test(url)) {
       const [, id] = url.match(this.idRegexp) || [];
@@ -117,7 +119,8 @@ export class YouTubeProvider extends BaseProvider {
   }
 
   private _onStateChange(event: YT.OnStateChangeEvent): void {
-    switch (+event.data) {
+    const newState = +event.data;
+    switch (newState) {
       case PlayerStates.PLAYING:
         this.component._onPlay();
         break;
@@ -131,7 +134,12 @@ export class YouTubeProvider extends BaseProvider {
           this.component._onEnded();
         }
         break;
+      case PlayerStates.UNSTARTED:
+        if (this.lastPlayerState === PlayerStates.PLAYING || this.lastPlayerState === PlayerStates.PAUSED) this.component._onEnded();
+        break;
     }
+
+    this.lastPlayerState = newState;
   }
 
   protected override onConfigChange(param: ProviderObservedParams, value: boolean): void {


### PR DESCRIPTION
Closes: #2912

The issue was caused by an interesting behavior of YouTube api:
Basically we were expecting for `PlayerState.ENDED` event to be triggered once video is stopped. But it doesn't. It only happens when video was watched until the end and then automatically stopped.

Behavior is different with a manual stop:
The behavior i got was two event triggered a stop - `PlayerState.UNSTARTED` (-1) and `PlayerState.CUED` (5).

And the [YT API](https://developers.google.com/youtube/iframe_api_reference#Playback_controls) says, that the stopVideo function could put the player into any not-playing state, including ended (0), paused (2), video cued (5) or unstarted (-1).

My guess that unstarted (-1) is triggered every time when video is at 0 seconds and shows sort of the 'preview' state.

I couldn't find any good proposals to address the issue, so decided if player was in playing or paused state and then abruptly put in unstarted state, it means it was manually paused