### PR TITLE
fix(esl-carousel): fix initial CLS for looped carousels

### DIFF
--- a/src/modules/esl-carousel/README.md
+++ b/src/modules/esl-carousel/README.md
@@ -168,11 +168,13 @@ The following renderers are available out of the box:
 The default renderer for ESL Carousel. Uses the flexbox layout to display slides. 
 Moves the slides with CSS transitions of the scene `transform` property.
 If the `loop` attribute is set to `true`, the renderer will reorder the slides with a flexbox order property to create the loop effect.
+By default try to move half of remaining slides to the opposite side of the carousel if loop is enabled.
+However, you can forbid this behavior by setting `lazy-reorder` attribute (supprts `ESLMediaQuery` syntax), so the renderer will move slide only during the animation.
 Does not do any DOM manipulations with the slides.
 Supports the posibility to show multiple slides at once as well as siblings visibility effect (the next and previous slides are partially visible).
 Supoorst all ESLCarousel attributes and properties including `vertical` and `step-duration`.
 
-To fine tune the layout you can use the following CSS recepies:
+To fine tune the layout you can use the following recepies:
   1. Slide size:
     The carousel renderer defines the `--esl-slide-size` (readonly) CSS variable with the size of the slide according to the carousel calculations.
     However, we do not recomend to rely on it to render first slide. It is recommended to define `width` or `height` for the slide elements explicitly.
@@ -189,6 +191,11 @@ To fine tune the layout you can use the following CSS recepies:
     However, the start position and calculations are based on `esl-carousel-slides` container element.
     You can utilize this to create siblings visibility effect by setting margin to the `esl-carousel-slides` container.
     Note that out of the box ESL Carousel already utilizes that trick to set visibility tolerance, you can adjust the out of the box behavior with `--esl-carousel-side-space` CSS variable as well.
+  5. Limit reordering in loop mode (Could be useful to limit CLS issues, when content of the slide is heavy):
+    By default, the renderer will reorder/move a half of the remaining slides to the opposite side of the carousel if loop is enabled.
+    You can forbid this behavior by setting `lazy-reorder` attribute. It is an `ESLMediaQuery`, so you can define it for specific media conditions.
+    Note that if you usin siblings visibility effect, you will not see the last slide before the first one in the loop mode unless backword animation is playing.
+    However, this option could be useful to limit CLS issues, when content of the slide is heavy (e.g. `esl-media` with the fill option).
 
 - #### Grid (type: `grid`) Renderer <i class="badge badge-sup badge-warning">beta</i>
 The grid renderer for ESL Carousel is based on the Default renderer but uses the CSS Grid layout to display slides.

--- a/src/modules/esl-carousel/README.md
+++ b/src/modules/esl-carousel/README.md
@@ -169,12 +169,12 @@ The default renderer for ESL Carousel. Uses the flexbox layout to display slides
 Moves the slides with CSS transitions of the scene `transform` property.
 If the `loop` attribute is set to `true`, the renderer will reorder the slides with a flexbox order property to create the loop effect.
 By default try to move half of remaining slides to the opposite side of the carousel if loop is enabled.
-However, you can forbid this behavior by setting `lazy-reorder` attribute (supprts `ESLMediaQuery` syntax), so the renderer will move slide only during the animation.
+However, you can forbid this behavior by setting `lazy-reorder` attribute (which supports `ESLMediaQuery` syntax), so the renderer will move slide only during the animation.
 Does not do any DOM manipulations with the slides.
 Supports the posibility to show multiple slides at once as well as siblings visibility effect (the next and previous slides are partially visible).
 Supoorst all ESLCarousel attributes and properties including `vertical` and `step-duration`.
 
-To fine tune the layout you can use the following recepies:
+To fine-tune the layout you can use the following recipes:
   1. Slide size:
     The carousel renderer defines the `--esl-slide-size` (readonly) CSS variable with the size of the slide according to the carousel calculations.
     However, we do not recomend to rely on it to render first slide. It is recommended to define `width` or `height` for the slide elements explicitly.
@@ -194,7 +194,7 @@ To fine tune the layout you can use the following recepies:
   5. Limit reordering in loop mode (Could be useful to limit CLS issues, when content of the slide is heavy):
     By default, the renderer will reorder/move a half of the remaining slides to the opposite side of the carousel if loop is enabled.
     You can forbid this behavior by setting `lazy-reorder` attribute. It is an `ESLMediaQuery`, so you can define it for specific media conditions.
-    Note that if you usin siblings visibility effect, you will not see the last slide before the first one in the loop mode unless backword animation is playing.
+    Note that if you use siblings visibility effect, you will not see the last slide before the first one in the loop mode unless backward animation is playing.
     However, this option could be useful to limit CLS issues, when content of the slide is heavy (e.g. `esl-media` with the fill option).
 
 - #### Grid (type: `grid`) Renderer <i class="badge badge-sup badge-warning">beta</i>

--- a/src/modules/esl-carousel/core/esl-carousel.less
+++ b/src/modules/esl-carousel/core/esl-carousel.less
@@ -1,4 +1,5 @@
 :root {
+  --esl-slide-initial-size: 100%;
   --esl-carousel-side-space: 5px;
 }
 
@@ -16,6 +17,11 @@ esl-carousel {
   overflow: hidden; // Fallback
   overflow: clip;
   /* stylelint-enable */
+
+  &:not(.esl-carousel) [esl-carousel-slide] {
+    max-width: 100%;
+    max-height: 100%;
+  }
 
   &.esl-carousel-vertical {
     [esl-carousel-slides] {

--- a/src/modules/esl-carousel/renderers/esl-carousel.default.renderer.less
+++ b/src/modules/esl-carousel/renderers/esl-carousel.default.renderer.less
@@ -8,9 +8,9 @@
   }
 
   &.esl-carousel-horizontal [esl-carousel-slide] {
-    width: var(--esl-slide-size, --esl-slide-initial-size, 100%);
+    width: var(--esl-slide-size, var(--esl-slide-initial-size));
   }
   &.esl-carousel-vertical [esl-carousel-slide] {
-    height: var(--esl-slide-size, --esl-slide-initial-size, 100%);
+    height: var(--esl-slide-size, var(--esl-slide-initial-size));
   }
 }

--- a/src/modules/esl-carousel/renderers/esl-carousel.default.renderer.ts
+++ b/src/modules/esl-carousel/renderers/esl-carousel.default.renderer.ts
@@ -55,10 +55,10 @@ export class ESLDefaultCarouselRenderer extends ESLCarouselRenderer {
   }
 
   public override redraw(initial = false): void {
+    this.resize();
+
     // Calculate initial offset based on current rendered state (available only on an initial render)
     const fallbackOffset = initial ? this.getOffset(this.getReserveCount()) : 0;
-
-    this.resize();
     this.reorder();
     this.setActive(this.currentIndex);
 

--- a/src/modules/esl-carousel/renderers/esl-carousel.default.renderer.ts
+++ b/src/modules/esl-carousel/renderers/esl-carousel.default.renderer.ts
@@ -48,14 +48,9 @@ export class ESLDefaultCarouselRenderer extends ESLCarouselRenderer {
 
   public override redraw(initial = false): void {
     this.resize();
-    // Calculate initial offset based on current rendered state (available only on an initial render)
-    const fallbackOffset = initial ? this.getOffset(this.getReserveCount()) : 0;
-
     this.reorder();
     this.setActive(this.currentIndex);
 
-    // Set initial offset based on pre-calculation
-    initial && this.setTransformOffset(-fallbackOffset);
     // Update offset according to main algorithm (fix edge cases if the fallback offset is not correct)
     this.setTransformOffset(-this.getOffset(this.currentIndex));
   }

--- a/src/modules/esl-carousel/renderers/esl-carousel.default.renderer.ts
+++ b/src/modules/esl-carousel/renderers/esl-carousel.default.renderer.ts
@@ -51,14 +51,19 @@ export class ESLDefaultCarouselRenderer extends ESLCarouselRenderer {
    */
   public override onBind(): void {
     this.currentIndex = this.normalizeIndex(Math.max(0, this.$carousel.activeIndex));
-    this.redraw();
+    this.redraw(true);
   }
 
-  public override redraw(): void {
+  public override redraw(initial = false): void {
+    // Calculate initial offset based on current rendered state (available only on an initial render)
+    const fallbackOffset = initial ? this.getOffset(this.getReserveCount()) : 0;
+
     this.resize();
     this.reorder();
     this.setActive(this.currentIndex);
 
+    // Set initial offset based on pre-calculation
+    initial && this.setTransformOffset(-fallbackOffset);
     // Update offset according to main algorithm (fix edge cases if the fallback offset is not correct)
     this.setTransformOffset(-this.getOffset(this.currentIndex));
   }


### PR DESCRIPTION
Note: the root cause was found in the carousel slide initial styles for dimensions
Closes: #2879