### PR TITLE
fix(esl-scrollbar): inconsistent dragging if target is `html`

### DIFF
--- a/src/modules/esl-scrollbar/core/esl-scrollbar.ts
+++ b/src/modules/esl-scrollbar/core/esl-scrollbar.ts
@@ -240,7 +240,7 @@ export class ESLScrollbar extends ESLBaseElement {
   protected _onPointerDown(event: PointerEvent): void {
     this._initialPosition = this.position;
     this._pointerPosition = this.toPosition(event);
-    this._initialMousePosition = this.horizontal ? event.pageX : event.pageY;
+    this._initialMousePosition = this.horizontal ? event.pageX - window.scrollX : event.pageY - window.scrollY;
 
     if (event.target === this.$scrollbarThumb) {
       this._onThumbPointerDown(event); // Drag start handler
@@ -277,7 +277,7 @@ export class ESLScrollbar extends ESLBaseElement {
   /** Sets position on drag */
   protected _onPointerDrag(event: PointerEvent): void {
     const point = getTouchPoint(event);
-    const mousePosition = this.horizontal ? point.x : point.y;
+    const mousePosition = this.horizontal ? point.x - window.scrollX : point.y - window.scrollY;
     const positionChange = mousePosition - this._initialMousePosition;
     const scrollableAreaHeight = this.trackOffset - this.thumbOffset;
     const absChange = scrollableAreaHeight ? (positionChange / scrollableAreaHeight) : 0;


### PR DESCRIPTION
Closes: #2959

Issue was happening because scrollbar implementation utilizes pageX/Y for scroll calculations and was expecting that these values are not modifiable. But scrolling `html` does actually modify them, and was causing sequence of drag events to quadruple its coordinates. For example: 
The regular scrolling down would look like (+2px, +2px, +3px, + 2px, ....) 
Made html scrolling look like (+2px, +4px, +16px, +32px, +64px).

Instead of substraction scrollX/Y attempt was made to utilize clientX/Y, since it represents viewport coordinates, but it made nested scrollbars break and work in opposite direction if the outer one was modified.