### PR TITLE
chore(deps): update @exadel/ui-playground to version 2.1.0-beta.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1348,22 +1348,20 @@
       "link": true
     },
     "node_modules/@exadel/ui-playground": {
-      "version": "2.1.0-beta.7",
-      "resolved": "https://registry.npmjs.org/@exadel/ui-playground/-/ui-playground-2.1.0-beta.7.tgz",
-      "integrity": "sha512-FAUk1alqU3ul3bpRknoCvfRLYq91Mnqey/xhQxu2MEhTnE3+B5zs9BDsa0QCI2c1DqDwUJ+MWhZSgBiXYOG6zg==",
+      "version": "2.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/@exadel/ui-playground/-/ui-playground-2.1.0-beta.10.tgz",
+      "integrity": "sha512-nLp7rMvq8aC3FgqBHiW70DmEaoibzglckk5KL1w5NPbubQF15yAA5yIv/atw7Qoot1DweiSx4FYCa0QO4Eaqlg==",
       "workspaces": [
         "site"
       ],
       "dependencies": {
+        "@exadel/esl": "^5.0.0",
         "codejar": "^4.2.0",
         "jsx-dom": "6.4.23",
         "prismjs": "^1.29.0"
       },
       "engines": {
         "node": ">=18.17.0"
-      },
-      "peerDependencies": {
-        "@exadel/esl": "^4.13.0 || ^5.0.0 || ^5.0.0-beta.0"
       }
     },
     "node_modules/@hapi/hoek": {
@@ -21882,7 +21880,7 @@
         "@11ty/eleventy": "^3.0.0",
         "@11ty/eleventy-dev-server": "^2.0.8",
         "@exadel/esl": "../esl",
-        "@exadel/ui-playground": "2.1.0-beta.7",
+        "@exadel/ui-playground": "2.1.0-beta.10",
         "@juggle/resize-observer": "^3.4.0",
         "@types/prismjs": "^1.26.5",
         "@types/smoothscroll-polyfill": "^0.3.4",

--- a/packages/esl-website/package.json
+++ b/packages/esl-website/package.json
@@ -34,7 +34,7 @@
     "@11ty/eleventy": "^3.0.0",
     "@11ty/eleventy-dev-server": "^2.0.8",
     "@exadel/esl": "../esl",
-    "@exadel/ui-playground": "2.1.0-beta.7",
+    "@exadel/ui-playground": "2.1.0-beta.10",
     "@juggle/resize-observer": "^3.4.0",
     "@types/prismjs": "^1.26.5",
     "@types/smoothscroll-polyfill": "^0.3.4",
@@ -49,5 +49,8 @@
     "webpack": "^5.98.0",
     "webpack-bundle-analyzer": "^4.10.2",
     "webpack-cli": "^6.0.1"
+  },
+  "overrides": {
+    "@exadel/esl": "../esl"
   }
 }


### PR DESCRIPTION
Note: now uses override to use a local version of esl package