### PR TITLE
fix(esl-carousel): fix navigation collision logging and handling, fix `canNavigate` behaviour

### DIFF
--- a/packages/esl/src/esl-carousel/core/esl-carousel.errors.ts
+++ b/packages/esl/src/esl-carousel/core/esl-carousel.errors.ts
@@ -1,0 +1,14 @@
+/**
+ * Custom error that ESLCarousel throws when navigation is rejected due to ongoing animation.
+ * By default, it does not include a stack trace to avoid cluttering the console.
+ */
+export class ESLCarouselNavRejection extends Error {
+  /** Debug mode to enable stack trace in the error log */
+  public static debug = false;
+
+  constructor(index: number | string) {
+    super(`Navigation skipped to index ${index} due to ongoing animation`);
+    this.name = '[ESL] Carousel Rejection';
+    if (!ESLCarouselNavRejection.debug) this.stack = undefined; // disable stack trace
+  }
+}

--- a/packages/esl/src/esl-carousel/core/esl-carousel.renderer.ts
+++ b/packages/esl/src/esl-carousel/core/esl-carousel.renderer.ts
@@ -142,20 +142,21 @@ export abstract class ESLCarouselRenderer implements ESLCarouselConfig {
     const details = {...params, direction, indexesBefore, indexesAfter};
     if (!this.$carousel.dispatchEvent(ESLCarouselSlideEvent.create('BEFORE', details))) return;
 
-    this.$carousel.dispatchEvent(ESLCarouselSlideEvent.create('CHANGE', details));
     this.setPreActive(index);
+    this.$carousel.dispatchEvent(ESLCarouselSlideEvent.create('CHANGE', details));
 
     this.transitionDuration = params.stepDuration;
     try {
       await this.onBeforeAnimate(index, direction, params);
       await this.onAnimate(index, direction, params);
       await this.onAfterAnimate(index, direction, params);
-    } catch (e: unknown) {
-      console.error(e);
-    }
-    this.transitionDuration = null;
 
-    this.setActive(index, {direction, ...params});
+      this.setActive(index, {direction, ...params});
+    } catch (e: unknown) {
+      if (e instanceof Error) throw e;
+    } finally {
+      this.transitionDuration = null;
+    }
   }
 
   /** Pre-processing animation action. */

--- a/packages/esl/src/esl-carousel/core/esl-carousel.ts
+++ b/packages/esl/src/esl-carousel/core/esl-carousel.ts
@@ -228,7 +228,7 @@ export class ESLCarousel extends ESLBaseElement {
     const detail = e.detail || {};
     if (!isMatches(this, detail.match)) return;
     const index = this.$slides.findIndex(($slide) => $slide.contains(e.target as Element));
-    if (index !== -1 && !this.isActive(index)) this.goTo(index);
+    if (index !== -1 && !this.isActive(index)) this.goTo(index).catch(console.debug);
   }
 
   /** @returns slides that are processed by the current carousel. */

--- a/packages/esl/src/esl-carousel/core/esl-carousel.utils.ts
+++ b/packages/esl/src/esl-carousel/core/esl-carousel.utils.ts
@@ -10,6 +10,9 @@ import type {
 /** @returns sign of the value */
 export const sign = (value: number): -1 | 1 | 0 => value > 0 ? 1 : value < 0 ? -1 : 0;
 
+const bounds =
+  (value: number, min: number, max: number): number => Math.max(min, Math.min(max, value));
+
 /** @returns normalized slide index in bounds of [0, count] range */
 export function normalize(index: number, size: number): number {
   return (size + (index % size)) % size;
@@ -17,7 +20,7 @@ export function normalize(index: number, size: number): number {
 
 /** @returns normalize first slide index according to the carousel mode */
 export function normalizeIndex(index: number, {size, count, loop}: ESLCarouselStaticState): number {
-  return loop && count < size ? normalize(index, size) : Math.max(0, Math.min(size - count, index));
+  return loop && count < size ? normalize(index, size) : bounds(index, 0, size - count);
 }
 
 /** @returns normalized sequence of slides starting from the current index */
@@ -129,5 +132,5 @@ export function canNavigate(target: ESLCarouselSlideTarget, cfg: ESLCarouselStat
   if (cfg.size <= cfg.count) return false;
   const {direction, index} = toIndex(target, cfg);
   if (!cfg.loop && direction && index < direction * cfg.activeIndex) return false;
-  return !!direction && index !== cfg.activeIndex;
+  return index !== cfg.activeIndex;
 }

--- a/packages/esl/src/esl-carousel/plugin/autoplay/esl-carousel.autoplay.mixin.ts
+++ b/packages/esl/src/esl-carousel/plugin/autoplay/esl-carousel.autoplay.mixin.ts
@@ -117,7 +117,7 @@ export class ESLCarouselAutoplayMixin extends ESLCarouselPlugin<ESLCarouselAutop
   protected async _onCycle(exec?: boolean): Promise<void> {
     this._duration && window.clearTimeout(this._duration);
     this._duration = null;
-    if (exec) await this.$host?.goTo(this.config.command);
+    if (exec) await this.$host?.goTo(this.config.command).catch(console.debug);
     if (!this.enabled || this.active) return;
     const {duration} = this;
     this._duration = window.setTimeout(() => this._onCycle(true), duration);

--- a/packages/esl/src/esl-carousel/plugin/dots/esl-carousel.nav.dots.ts
+++ b/packages/esl/src/esl-carousel/plugin/dots/esl-carousel.nav.dots.ts
@@ -189,7 +189,7 @@ export class ESLCarouselNavDots extends ESLBaseElement {
     if (!this.$carousel || typeof this.$carousel.goTo !== 'function') return;
     const $btn = event.$delegate as HTMLElement;
     const target = $btn.getAttribute('esl-carousel-dot') || '';
-    this.$carousel.goTo(`group:${+target}`);
+    this.$carousel.goTo(`group:${+target}`).catch(console.debug);
     (this.tabIndex >= 0 ? this : $btn).focus({preventScroll: true});
   }
 

--- a/packages/esl/src/esl-carousel/plugin/keyboard/esl-carousel.keyboard.mixin.ts
+++ b/packages/esl/src/esl-carousel/plugin/keyboard/esl-carousel.keyboard.mixin.ts
@@ -28,13 +28,21 @@ export class ESLCarouselKeyboardMixin extends ESLCarouselPlugin<ESLCarouselKeybo
     return this.$host.config.vertical ? ARROW_UP : ARROW_LEFT;
   }
 
+  /** @returns result command for carousel */
+  protected getCommandFromKey(key: string): string {
+    const {command} = this.config;
+    if (command === 'none') return '';
+    if (key === this.nextKey) return `${command || 'slide'}:next`;
+    if (key === this.prevKey) return `${command || 'slide'}:prev`;
+    return '';
+  }
+
   /** Handles `keydown` event */
   @listen('keydown')
   protected _onKeydown(event: KeyboardEvent): void {
-    const {command} = this.config;
-    if (!this.$host || this.$host.animating || command === 'none') return;
-    if (event.key === this.nextKey) this.$host.goTo(`${command || 'slide'}:next`);
-    if (event.key === this.prevKey) this.$host.goTo(`${command || 'slide'}:prev`);
+    if (!this.$host || this.$host.animating) return;
+    const command = this.getCommandFromKey(event.key);
+    command && this.$host.goTo(command).catch(console.debug);
   }
 }
 

--- a/packages/esl/src/esl-carousel/plugin/nav/esl-carousel.nav.mixin.ts
+++ b/packages/esl/src/esl-carousel/plugin/nav/esl-carousel.nav.mixin.ts
@@ -76,7 +76,7 @@ export class ESLCarouselNavMixin extends ESLMixinElement {
   @listen('click')
   protected _onClick(e: PointerEvent): void {
     if (!this.$carousel || typeof this.$carousel.goTo !== 'function') return;
-    this.$carousel.goTo(this.command).catch(console.error);
+    this.$carousel.goTo(this.command).catch(console.debug);
     e.preventDefault();
   }
 }

--- a/packages/esl/src/esl-carousel/plugin/relation/esl-carousel.relation.mixin.ts
+++ b/packages/esl/src/esl-carousel/plugin/relation/esl-carousel.relation.mixin.ts
@@ -44,7 +44,7 @@ export class ESLCarouselRelateToMixin extends ESLCarouselPlugin<ESLCarouselRelat
   @listen({event: ($this: ESLCarouselRelateToMixin) => $this.event})
   protected _onSlideChange(e: ESLCarouselSlideEvent): void {
     if (!this.$target || e.activator === this) return;
-    this.$target.goTo(this.$host.activeIndex, {activator: this});
+    this.$target.goTo(this.$host.activeIndex, {activator: this}).catch(console.debug);
   }
 }
 

--- a/packages/esl/src/esl-carousel/plugin/touch/esl-carousel.touch.mixin.ts
+++ b/packages/esl/src/esl-carousel/plugin/touch/esl-carousel.touch.mixin.ts
@@ -143,7 +143,7 @@ export class ESLCarouselTouchMixin extends ESLCarouselPlugin<ESLCarouselTouchCon
     // Swipe final check
     if (this.isSwipeMode && offset && !this.isPrevented && this.isSwipeAccepted(event)) {
       const target = `${this.config.swipeType}:${offset < 0 ? 'next' : 'prev'}`;
-      if (this.$host.canNavigate(target)) this.$host.goTo(target, {activator: this});
+      if (this.$host.canNavigate(target)) this.$host.goTo(target, {activator: this}).catch(console.debug);
     }
   }
 }

--- a/packages/esl/src/esl-carousel/plugin/wheel/esl-carousel.wheel.mixin.ts
+++ b/packages/esl/src/esl-carousel/plugin/wheel/esl-carousel.wheel.mixin.ts
@@ -77,7 +77,7 @@ export class ESLCarouselWheelMixin extends ESLCarouselPlugin<ESLCarouselWheelCon
     if (!this.$host || this.$host.animating) return;
     const delta = this.isVertical ? e.deltaY : e.deltaX;
     const direction = delta > 0 ? 'next' : 'prev';
-    this.$host?.goTo(`${this.config.command || 'slide'}:${direction}`);
+    this.$host?.goTo(`${this.config.command || 'slide'}:${direction}`).catch(console.debug);
   }
 }
 

--- a/packages/esl/src/esl-carousel/renderers/esl-carousel.css.renderer.ts
+++ b/packages/esl/src/esl-carousel/renderers/esl-carousel.css.renderer.ts
@@ -2,6 +2,7 @@ import {promisifyNextRender} from '../../esl-utils/async/promise';
 import {ESLCarouselRenderer} from '../core/esl-carousel.renderer';
 import {CSSClassUtils} from '../../esl-utils/dom/class';
 import {ESLCarouselDirection} from '../core/esl-carousel.types';
+import {ESLCarouselNavRejection} from '../core/esl-carousel.errors';
 
 import type {ESLCarouselActionParams} from '../core/esl-carousel.types';
 
@@ -56,7 +57,7 @@ export class ESLCSSCarouselRenderer extends ESLCarouselRenderer {
 
   /** Pre-processing animation action. */
   public override async onBeforeAnimate(index: number, direction: ESLCarouselDirection, params: ESLCarouselActionParams): Promise<void> {
-    if (this.animating) throw new Error('[ESL] Carousel: already animating');
+    if (this.animating) throw new ESLCarouselNavRejection(index);
     return promisifyNextRender();
   }
 

--- a/packages/esl/src/esl-carousel/renderers/esl-carousel.default.renderer.ts
+++ b/packages/esl/src/esl-carousel/renderers/esl-carousel.default.renderer.ts
@@ -1,6 +1,7 @@
 import {ESLMediaQuery} from '../../esl-media-query/core';
 import {normalize, sign} from '../core/esl-carousel.utils';
 import {ESLCarouselRenderer} from '../core/esl-carousel.renderer';
+import {ESLCarouselNavRejection} from '../core/esl-carousel.errors';
 
 import type {ESLCarouselDirection, ESLCarouselActionParams} from '../core/esl-carousel.types';
 
@@ -104,8 +105,8 @@ export class ESLDefaultCarouselRenderer extends ESLCarouselRenderer {
   }
 
   /** Pre-processing animation action. */
-  public override async onBeforeAnimate(nextIndex: number, direction: ESLCarouselDirection, params: ESLCarouselActionParams): Promise<void> {
-    if (this.animating) throw new Error('[ESL] Carousel: already animating');
+  public override async onBeforeAnimate(index: number, direction: ESLCarouselDirection, params: ESLCarouselActionParams): Promise<void> {
+    if (this.animating) throw new ESLCarouselNavRejection(index);
     this.$carousel.$$attr('active', true);
   }
 

--- a/packages/esl/src/esl-carousel/test/core/esl-carousel.utils.base.test.ts
+++ b/packages/esl/src/esl-carousel/test/core/esl-carousel.utils.base.test.ts
@@ -1,15 +1,8 @@
-import {
-  normalize,
-  groupToIndex,
-  indexToGroup,
-  indexToDirection,
-  toIndex, canNavigate
-} from '../../core/esl-carousel.utils';
+import {normalize, groupToIndex, indexToGroup, indexToDirection, toIndex} from '../../core/esl-carousel.utils';
 import {ESLCarouselDirection} from '../../core/esl-carousel.types';
-
 import type {ESLCarouselSlideTarget, ESLCarouselState} from '../../core/esl-carousel.types';
 
-describe('ESLCarousel: Nav Utils', () => {
+describe('ESLCarousel: Nav Utils (Core)', () => {
   describe('normalize', () => {
     test.each([
       // [index, size, result]
@@ -284,57 +277,5 @@ describe('ESLCarousel: Nav Utils', () => {
         (target: ESLCarouselSlideTarget, cfg: ESLCarouselState, result: number) => expect(toIndex(target, cfg).index).toBe(result)
       );
     });
-  });
-
-  describe('canNavigate',  () => {
-    test.each([
-      // Loop for complete
-      ['next', {activeIndex: 0, size: 5, count: 1, loop: true}],
-      ['prev', {activeIndex: 0, size: 5, count: 1, loop: true}],
-      ['next', {activeIndex: 4, size: 5, count: 1, loop: true}],
-      // Non loop case with free space
-      ['next', {activeIndex: 0, size: 5, count: 1, loop: false}],
-      ['prev', {activeIndex: 4, size: 5, count: 1, loop: false}],
-      ['next', {activeIndex: 2, size: 5, count: 1, loop: false}],
-      ['prev', {activeIndex: 2, size: 5, count: 1, loop: false}],
-      // Group cases
-      ['group: next', {activeIndex: 0, size: 5, count: 2, loop: true}],
-      ['group: prev', {activeIndex: 0, size: 5, count: 2, loop: true}],
-      ['group: next', {activeIndex: 4, size: 5, count: 2, loop: true}],
-      ['group: prev', {activeIndex: 4, size: 5, count: 2, loop: true}],
-      // Non loop case with free space
-      ['group: next', {activeIndex: 0, size: 5, count: 2, loop: false}],
-      ['group: prev', {activeIndex: 2, size: 5, count: 2, loop: false}],
-      ['group: prev', {activeIndex: 4, size: 5, count: 2, loop: false}]
-    ])(
-      'Target %s is allowed for %p configuration',
-      (target: ESLCarouselSlideTarget, cfg: ESLCarouselState) => expect(canNavigate(target, cfg)).toBe(true)
-    );
-
-    test.each([
-      // Non loop case with no free space
-      ['next', {activeIndex: 4, size: 5, count: 1, loop: false}],
-      ['prev', {activeIndex: 0, size: 5, count: 1, loop: false}],
-      // Incomplete cases
-      ['next', {activeIndex: 0, size: 1, count: 1, loop: false}],
-      ['prev', {activeIndex: 0, size: 1, count: 1, loop: false}],
-      ['next', {activeIndex: 0, size: 1, count: 1, loop: true}],
-      ['prev', {activeIndex: 0, size: 1, count: 1, loop: true}],
-      ['next', {activeIndex: 0, size: 2, count: 2, loop: true}],
-      ['prev', {activeIndex: 0, size: 2, count: 2, loop: true}],
-      ['next', {activeIndex: 0, size: 1, count: 2, loop: true}],
-      ['prev', {activeIndex: 0, size: 1, count: 2, loop: true}],
-      // Same slide
-      ['0', {activeIndex: 0, size: 5, count: 1, loop: false}],
-      ['0', {activeIndex: 0, size: 5, count: 1, loop: true}],
-      ['1', {activeIndex: 1, size: 5, count: 2, loop: false}],
-      ['1', {activeIndex: 1, size: 5, count: 2, loop: true}],
-      // Group cases with no loop
-      ['group: next', {activeIndex: 4, size: 5, count: 2, loop: false}],
-      ['group: prev', {activeIndex: 0, size: 5, count: 2, loop: false}]
-    ])(
-      'Target %s is not allowed for %p configuration',
-      (target: ESLCarouselSlideTarget, cfg: ESLCarouselState) => expect(canNavigate(target, cfg)).toBe(false)
-    );
   });
 });

--- a/packages/esl/src/esl-carousel/test/core/esl-carousel.utils.nav.test.ts
+++ b/packages/esl/src/esl-carousel/test/core/esl-carousel.utils.nav.test.ts
@@ -1,0 +1,66 @@
+import {canNavigate} from '../../core/esl-carousel.utils';
+import type {ESLCarouselSlideTarget, ESLCarouselState} from '../../core/esl-carousel.types';
+
+describe('ESLCarousel: Nav Utils', () => {
+  describe('canNavigate',  () => {
+    test.each([
+      // Loop for complete
+      ['next', {activeIndex: 0, size: 5, count: 1, loop: true}],
+      ['prev', {activeIndex: 0, size: 5, count: 1, loop: true}],
+      ['next', {activeIndex: 4, size: 5, count: 1, loop: true}],
+      // Non loop case with free space
+      ['next', {activeIndex: 0, size: 5, count: 1, loop: false}],
+      ['prev', {activeIndex: 4, size: 5, count: 1, loop: false}],
+      ['next', {activeIndex: 2, size: 5, count: 1, loop: false}],
+      ['prev', {activeIndex: 2, size: 5, count: 1, loop: false}],
+      // Group cases
+      ['group: next', {activeIndex: 0, size: 5, count: 2, loop: true}],
+      ['group: prev', {activeIndex: 0, size: 5, count: 2, loop: true}],
+      ['group: next', {activeIndex: 4, size: 5, count: 2, loop: true}],
+      ['group: prev', {activeIndex: 4, size: 5, count: 2, loop: true}],
+      // Non loop case with free space
+      ['group: next', {activeIndex: 0, size: 5, count: 2, loop: false}],
+      ['group: prev', {activeIndex: 2, size: 5, count: 2, loop: false}],
+      ['group: prev', {activeIndex: 4, size: 5, count: 2, loop: false}],
+      // Indexes
+      ['slide:1', {activeIndex: 0, size: 4, count: 1, loop: true}],
+      ['slide:2', {activeIndex: 0, size: 4, count: 1, loop: true}],
+      ['slide:3', {activeIndex: 0, size: 4, count: 1, loop: true}],
+      ['slide:0', {activeIndex: 1, size: 4, count: 1, loop: true}],
+      ['slide:2', {activeIndex: 1, size: 4, count: 1, loop: true}],
+      ['slide:3', {activeIndex: 1, size: 4, count: 1, loop: true}],
+    ])(
+      'Target %s is allowed for %p configuration',
+      (target: ESLCarouselSlideTarget, cfg: ESLCarouselState) => expect(canNavigate(target, cfg)).toBe(true)
+    );
+
+    test.each([
+      // Non loop case with no free space
+      ['next', {activeIndex: 4, size: 5, count: 1, loop: false}],
+      ['prev', {activeIndex: 0, size: 5, count: 1, loop: false}],
+      // Incomplete cases
+      ['next', {activeIndex: 0, size: 1, count: 1, loop: false}],
+      ['prev', {activeIndex: 0, size: 1, count: 1, loop: false}],
+      ['next', {activeIndex: 0, size: 1, count: 1, loop: true}],
+      ['prev', {activeIndex: 0, size: 1, count: 1, loop: true}],
+      ['next', {activeIndex: 0, size: 2, count: 2, loop: true}],
+      ['prev', {activeIndex: 0, size: 2, count: 2, loop: true}],
+      ['next', {activeIndex: 0, size: 1, count: 2, loop: true}],
+      ['prev', {activeIndex: 0, size: 1, count: 2, loop: true}],
+      // Same slide
+      ['0', {activeIndex: 0, size: 5, count: 1, loop: false}],
+      ['0', {activeIndex: 0, size: 5, count: 1, loop: true}],
+      ['1', {activeIndex: 1, size: 5, count: 2, loop: false}],
+      ['1', {activeIndex: 1, size: 5, count: 2, loop: true}],
+      // Group cases with no loop
+      ['group: next', {activeIndex: 4, size: 5, count: 2, loop: false}],
+      ['group: prev', {activeIndex: 0, size: 5, count: 2, loop: false}],
+      // Indexes
+      ['slide:0', {activeIndex: 0, size: 4, count: 1, loop: true}],
+      ['slide:1', {activeIndex: 1, size: 4, count: 1, loop: true}]
+    ])(
+      'Target %s is not allowed for %p configuration',
+      (target: ESLCarouselSlideTarget, cfg: ESLCarouselState) => expect(canNavigate(target, cfg)).toBe(false)
+    );
+  });
+});


### PR DESCRIPTION
✅ DO NOT BE SCARED BY 15 FILES, 
Changes here are really small and granular, just 4 aspects updated here:
 - Small fix for the `canNavigate` method
 - Related tests added, tests for the whole method moved to a separate file to simplify support (line count limit)
 - Add consistent catch with debug log for the `goTo` method + special rejection Error implementation to reduce spam in the console
 - Fix `goTo` internal flow to handle collisions and renderer errors correctly