### PR TITLE
feat(esl-trigger): no-target attribute support out of the box, no console warning (default 'disabled' styles)

### DIFF
--- a/packages/esl-website/src/common/tabs.less
+++ b/packages/esl-website/src/common/tabs.less
@@ -89,6 +89,10 @@
     background-color 0.25s linear,
     color 0.25s linear;
 
+  &[no-target] {
+    display: none;
+  }
+
   &:focus,
   &:hover {
     @inactive-color: mix(@secondary-blue, #ccc, 50);

--- a/packages/esl/src/esl-tab/core/esl-tab.less
+++ b/packages/esl/src/esl-tab/core/esl-tab.less
@@ -1,3 +1,8 @@
 esl-tab {
   cursor: pointer;
+
+  // Default behaviour if no target is specified
+  &[no-target] {
+    display: none;
+  }
 }

--- a/packages/esl/src/esl-trigger/core/esl-base-trigger.ts
+++ b/packages/esl/src/esl-trigger/core/esl-base-trigger.ts
@@ -134,7 +134,8 @@ export abstract class ESLBaseTrigger extends ESLBaseElement {
   public updateState(): boolean {
     const {active, isTargetActive} = this;
 
-    this.toggleAttribute('active', isTargetActive);
+    this.$$attr('no-target', !this.$target);
+    this.$$attr('active', isTargetActive);
     const clsTarget = ESLTraversingQuery.first(this.activeClassTarget, this) as HTMLElement;
     clsTarget && CSSClassUtils.toggle(clsTarget, this.activeClass, isTargetActive);
 
@@ -159,7 +160,8 @@ export abstract class ESLBaseTrigger extends ESLBaseElement {
   /** Handles ESLToggleable state change */
   @listen({
     event: (that: ESLBaseTrigger) => that.OBSERVED_EVENTS,
-    target: (that: ESLBaseTrigger) => that.$target
+    target: (that: ESLBaseTrigger) => that.$target,
+    condition: (that: ESLBaseTrigger) => !!that.$target
   })
   protected _onTargetStateChange(originalEvent?: Event): void {
     if (!this.updateState()) return;

--- a/packages/esl/src/esl-trigger/core/esl-trigger.less
+++ b/packages/esl/src/esl-trigger/core/esl-trigger.less
@@ -2,8 +2,6 @@ esl-trigger {
   cursor: pointer;
   // Default behaviour if no target is specified
   &[no-target] {
-    filter: grayscale(100%);
-    cursor: not-allowed;
-    pointer-events: none;
+    display: none;
   }
 }

--- a/packages/esl/src/esl-trigger/core/esl-trigger.less
+++ b/packages/esl/src/esl-trigger/core/esl-trigger.less
@@ -1,3 +1,9 @@
 esl-trigger {
   cursor: pointer;
+  // Default behaviour if no target is specified
+  &[no-target] {
+    filter: grayscale(100%);
+    cursor: not-allowed;
+    pointer-events: none;
+  }
 }

--- a/packages/esl/src/esl-trigger/core/esl-trigger.ts
+++ b/packages/esl/src/esl-trigger/core/esl-trigger.ts
@@ -62,12 +62,8 @@ export class ESLTrigger extends ESLBaseTrigger {
   /** Update `$target` Toggleable  from `target` selector */
   public updateTargetFromSelector(): void {
     if (!this.target) return;
-    this.$target = ESLTraversingQuery.first(this.target, this) as ESLToggleable;
-
-    if (this.$target instanceof ESLToggleablePlaceholder && this.$target.$origin) {
-      // change target if it is an instance of the placeholder element
-      this.$target = this.$target.$origin;
-    }
+    const $target = ESLTraversingQuery.first(this.target, this) as ESLToggleable | ESLToggleablePlaceholder;
+    this.$target = ($target instanceof ESLToggleablePlaceholder) ? $target.$origin : $target;
   }
 
   /** Check if the event target should be ignored */


### PR DESCRIPTION
It is as simple as it could be 
 - no warnings from the esl event listener to notify that there is no target for the trigger instance
 - simple and clear no-target readonly marker attribute indicating no target found
 - default styles so you can clearly understand -something wrong had happened (or you expected that, or you expeded and overrode it in CSS)
 
 The only question I have doubts about right now is - esl-tigger default styles
 A) simple but a little bit aggressive in general for abstract trigger `display: none`
 B) Some medium customization that you can observe currently in PR
 C) Some other thoughts?