### PR TITLE
fix(esl-popup): fix ESLPopup is still visible when the trigger is outside the viewport

### DIFF
--- a/packages/esl/src/esl-popup/core/esl-popup.ts
+++ b/packages/esl/src/esl-popup/core/esl-popup.ts
@@ -305,13 +305,13 @@ export class ESLPopup extends ESLToggleable {
   protected _onActivatorIntersection(event: ESLIntersectionEvent): void {
     this._intersectionRatio = {};
     if (!event.isIntersecting) {
-      this.hide();
+      this.hide({hideDelay: 0});
       return;
     }
 
     const isHorizontal = isOnHorizontalAxis(this.position);
     const checkIntersection = (isMajorAxis: boolean, intersectionRatio: number): void => {
-      if (isMajorAxis && intersectionRatio < INTERSECTION_LIMIT_FOR_ADJACENT_AXIS) this.hide();
+      if (isMajorAxis && intersectionRatio < INTERSECTION_LIMIT_FOR_ADJACENT_AXIS) this.hide({hideDelay: 0});
     };
     if (event.intersectionRect.y !== event.boundingClientRect.y) {
       this._intersectionRatio.top = event.intersectionRect.height / event.boundingClientRect.height;


### PR DESCRIPTION
Fixed issues:
 - [x]  forced hiding of the popup when its trigger leaves the viewport, for cases when a certain delay hideDelay is added to the popup
 - [ ] unclear definition of the moment when the trigger is considered to have left the viewport

Relates to: #3199 

