### PR TITLE
feat(esl-carousel):  introduce capabilities to provide custom autoplay restrictions

### DIFF
--- a/packages/esl/src/esl-carousel/plugin/autoplay/README.md
+++ b/packages/esl/src/esl-carousel/plugin/autoplay/README.md
@@ -26,6 +26,8 @@ Configuration properties:
  - `control` (optional) – selector for element(s) acting as manual enable/disable toggles.
  - `controlCls` (optional) – CSS class applied to external autoplay control elements while autoplay is enabled.
  - `containerCls` (optional) – CSS class applied to the carousel container while autoplay is enabled.
+ - `blockingItemsSelector` (optional) – selector (ESLTraversingQuery) for items that, when activated, stop carousel autoplay. Defaults to `esl-share[active], esl-note[active]`.
+ - `blockingEvents` (optional) – space-separated list of event names that toggle blocking state on the carousel when fired. Defaults to `esl:change:active`.
 
 ### Public properties / state
 

--- a/packages/esl/src/esl-carousel/plugin/autoplay/README.md
+++ b/packages/esl/src/esl-carousel/plugin/autoplay/README.md
@@ -26,7 +26,7 @@ Configuration properties:
  - `control` (optional) – selector for element(s) acting as manual enable/disable toggles.
  - `controlCls` (optional) – CSS class applied to external autoplay control elements while autoplay is enabled.
  - `containerCls` (optional) – CSS class applied to the carousel container while autoplay is enabled.
- - `blockerSelector` (optional) – selector (ESLTraversingQuery) for items that, when activated, stop carousel autoplay. Defaults to `esl-share[active], esl-note[active]`.
+ - `blockerSelector` (optional) – selector (ESLTraversingQuery) for items that, when activated, stop carousel autoplay. Defaults to `::find(esl-share[active], esl-note[active])`.
  - `watchEvents` (optional) – space-separated list of event names that toggle blocking state on the carousel when fired. Defaults to `esl:change:active`.
 
 ### Public properties / state

--- a/packages/esl/src/esl-carousel/plugin/autoplay/README.md
+++ b/packages/esl/src/esl-carousel/plugin/autoplay/README.md
@@ -26,7 +26,7 @@ Configuration properties:
  - `control` (optional) – selector for element(s) acting as manual enable/disable toggles.
  - `controlCls` (optional) – CSS class applied to external autoplay control elements while autoplay is enabled.
  - `containerCls` (optional) – CSS class applied to the carousel container while autoplay is enabled.
- - `blockSelector` (optional) – selector (ESLTraversingQuery) for items that, when activated, stop carousel autoplay. Defaults to `esl-share[active], esl-note[active]`.
+ - `blockerSelector` (optional) – selector (ESLTraversingQuery) for items that, when activated, stop carousel autoplay. Defaults to `esl-share[active], esl-note[active]`.
  - `watchEvents` (optional) – space-separated list of event names that toggle blocking state on the carousel when fired. Defaults to `esl:change:active`.
 
 ### Public properties / state

--- a/packages/esl/src/esl-carousel/plugin/autoplay/README.md
+++ b/packages/esl/src/esl-carousel/plugin/autoplay/README.md
@@ -26,8 +26,8 @@ Configuration properties:
  - `control` (optional) – selector for element(s) acting as manual enable/disable toggles.
  - `controlCls` (optional) – CSS class applied to external autoplay control elements while autoplay is enabled.
  - `containerCls` (optional) – CSS class applied to the carousel container while autoplay is enabled.
- - `blockingItemsSelector` (optional) – selector (ESLTraversingQuery) for items that, when activated, stop carousel autoplay. Defaults to `esl-share[active], esl-note[active]`.
- - `blockingEvents` (optional) – space-separated list of event names that toggle blocking state on the carousel when fired. Defaults to `esl:change:active`.
+ - `blockSelector` (optional) – selector (ESLTraversingQuery) for items that, when activated, stop carousel autoplay. Defaults to `esl-share[active], esl-note[active]`.
+ - `watchEvents` (optional) – space-separated list of event names that toggle blocking state on the carousel when fired. Defaults to `esl:change:active`.
 
 ### Public properties / state
 

--- a/packages/esl/src/esl-carousel/plugin/autoplay/esl-carousel.autoplay.mixin.ts
+++ b/packages/esl/src/esl-carousel/plugin/autoplay/esl-carousel.autoplay.mixin.ts
@@ -45,7 +45,7 @@ export class ESLCarouselAutoplayMixin extends ESLCarouselPlugin<ESLCarouselAutop
     command: 'slide:next',
     intersection: 0.25,
     trackInteraction: true,
-    blockerSelector: 'esl-share[active], esl-note[active]',
+    blockerSelector: '::find(esl-share[active], esl-note[active])',
     watchEvents: 'esl:change:active'
   };
   public static override DEFAULT_CONFIG_KEY: keyof ESLCarouselAutoplayConfig = 'duration';
@@ -121,7 +121,7 @@ export class ESLCarouselAutoplayMixin extends ESLCarouselPlugin<ESLCarouselAutop
   /** True if active slide contains any blocking items */
   public get hasActiveBlockingItems(): boolean {
     const {blockerSelector} = this.config;
-    return !!blockerSelector && this.$interactionScope.some(($el) => ESLTraversingQuery.first(blockerSelector, $el) !== null);
+    return !!blockerSelector && !!ESLTraversingQuery.first(blockerSelector, this.$host);
   }
 
   /** True if keyboard-visible focus is within scope */

--- a/packages/esl/src/esl-carousel/plugin/autoplay/esl-carousel.autoplay.mixin.ts
+++ b/packages/esl/src/esl-carousel/plugin/autoplay/esl-carousel.autoplay.mixin.ts
@@ -28,9 +28,9 @@ export interface ESLCarouselAutoplayConfig {
   /** CSS class applied to the carousel container while autoplay is enabled */
   containerCls?: string;
   /** Selector for items that, when active, should disable autoplay */
-  blockingItemsSelector?: string;
+  blockSelector?: string;
   /** Events that should block autoplay when fired on interaction scope elements */
-  blockingEvents?: string;
+  watchEvents?: string;
 }
 
 /**
@@ -45,8 +45,8 @@ export class ESLCarouselAutoplayMixin extends ESLCarouselPlugin<ESLCarouselAutop
     command: 'slide:next',
     intersection: 0.25,
     trackInteraction: true,
-    blockingItemsSelector: 'esl-share[active], esl-note[active]',
-    blockingEvents: 'esl:change:active'
+    blockSelector: 'esl-share[active], esl-note[active]',
+    watchEvents: 'esl:change:active'
   };
   public static override DEFAULT_CONFIG_KEY: keyof ESLCarouselAutoplayConfig = 'duration';
 
@@ -118,11 +118,12 @@ export class ESLCarouselAutoplayMixin extends ESLCarouselPlugin<ESLCarouselAutop
     return this.$interactionScope.some(($el) => $el.matches('*:hover'));
   }
 
+  /** True if active slide contains any blocking items */
   public get hasActiveBlockingItems(): boolean {
-    const {blockingItemsSelector} = this.config;
+    const {blockSelector} = this.config;
     const {$activeSlide} = this.$host;
 
-    return !!blockingItemsSelector && ESLTraversingQuery.first(blockingItemsSelector, $activeSlide) !== null;
+    return !!blockSelector && ESLTraversingQuery.first(blockSelector, $activeSlide) !== null;
   }
 
   /** True if keyboard-visible focus is within scope */
@@ -156,11 +157,11 @@ export class ESLCarouselAutoplayMixin extends ESLCarouselPlugin<ESLCarouselAutop
 
   /** Subscribe to events that block autoplay */
   protected subscribeToBlockingEvents(): void {
-    const {blockingEvents} = this.config;
-    if (!blockingEvents) return;
+    const {watchEvents} = this.config;
+    if (!watchEvents) return;
     this.$$on({
       group: 'state',
-      event: blockingEvents,
+      event: watchEvents,
       target: () => this.$interactionScope
     }, () => this.refresh());
   }

--- a/packages/esl/src/esl-trigger/core/esl-base-trigger.ts
+++ b/packages/esl/src/esl-trigger/core/esl-base-trigger.ts
@@ -14,7 +14,7 @@ import type {ESLToggleable, ESLToggleableActionParams} from '../../esl-toggleabl
 /** Base class for elements that should trigger {@link ESLToggleable} instance */
 export abstract class ESLBaseTrigger extends ESLBaseElement {
   /** Event that represents {@link ESLTrigger} state change */
-  @prop('') public CHANGE_EVENT: string;
+  @prop('esl:change:active') public CHANGE_EVENT: string;
   /** Events to observe target {@link ESLToggleable} instance state */
   @prop('esl:show esl:hide') public OBSERVED_EVENTS: string;
 

--- a/packages/esl/src/esl-trigger/core/esl-trigger.ts
+++ b/packages/esl/src/esl-trigger/core/esl-trigger.ts
@@ -1,6 +1,6 @@
 import {ExportNs} from '../../esl-utils/environment/export-ns';
 import {isElement} from '../../esl-utils/dom/api';
-import {attr, prop, ready} from '../../esl-utils/decorators';
+import {attr, ready} from '../../esl-utils/decorators';
 import {ESLTraversingQuery} from '../../esl-traversing-query/core';
 import {ESLToggleablePlaceholder} from '../../esl-toggleable/core';
 
@@ -13,9 +13,6 @@ import type {ESLToggleable} from '../../esl-toggleable/core/esl-toggleable';
 export class ESLTrigger extends ESLBaseTrigger {
   public static override is = 'esl-trigger';
   public static observedAttributes = ['target'];
-
-  /** Event that represents {@link ESLTrigger} state change */
-  @prop('esl:change:active') public override CHANGE_EVENT: string;
 
   /** Selector for ignored inner elements */
   @attr({defaultValue: 'a[href]'}) public ignore: string;

--- a/packages/esl/src/esl-utils/dom/events/misc.ts
+++ b/packages/esl/src/esl-utils/dom/events/misc.ts
@@ -47,6 +47,8 @@ export const getOffsetPoint = (el: Element): Point => {
  * @param eventInit - object that specifies characteristics of the event. See {@link CustomEventInit}
  */
 export const dispatchCustomEvent = (el: EventTarget, eventName: string, eventInit?: CustomEventInit): boolean => {
+  if (!eventName || !eventName.trim()) return true;
+
   const init = Object.assign({
     bubbles: true,
     composed: true,

--- a/packages/esl/src/esl-utils/dom/events/test/misc.test.ts
+++ b/packages/esl/src/esl-utils/dom/events/test/misc.test.ts
@@ -156,5 +156,10 @@ describe('dom/events: misc', () => {
       expect(event.bubbles).toBe(false);
       expect(event.cancelable).toBe(false);
     });
+
+    test('dispatchCustomEvent does not dispatch empty event', () => {
+      dispatchCustomEvent(el, '');
+      expect(el.dispatchEvent).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
1. Introduce options to specify selector for items that, when active, should disable autoplay and events that stop autoplay:
   - `blockingItemsSelector` (optional) – selector (ESLTraversingQuery) for items that, when activated, stop carousel autoplay. Defaults to `esl-share[active], esl-note[active]`.
   - `blockingEvents` (optional) – space-separated list of event names that toggle blocking state on the carousel when fired. Defaults to `esl:change:active`. 
2. Update esl-base-trigger and it's instances to dispatch `esl:change:action` by default .
3. Handle empty eventName in `dispatchCustomEvent` function.


Closes: [3349](https://github.com/exadel-inc/esl/issues/3349), [3371](https://github.com/exadel-inc/esl/issues/3371) 