### PR TITLE
refactor: remove deprecated properties and methods across ESL

### DIFF
--- a/packages/esl/src/esl-alert/core/esl-alert.ts
+++ b/packages/esl/src/esl-alert/core/esl-alert.ts
@@ -29,12 +29,6 @@ export class ESLAlert extends ESLToggleable {
   public static override is = 'esl-alert';
   public static override observedAttributes = ['target'];
 
-  /**
-   * Legacy default show/hide params for all ESLAlert instances
-   * @deprecated Use {@link ESLAlert.DEFAULT_PARAMS} instead
-   */
-  public static defaultConfig: ESLAlertActionParams = {};
-
   /** Default show/hide params for all ESLAlert instances */
   public static override DEFAULT_PARAMS: ESLAlertActionParams = {
     hideTime: 300,
@@ -74,7 +68,7 @@ export class ESLAlert extends ESLToggleable {
 
   protected override mergeDefaultParams(params?: ESLToggleableActionParams): ESLToggleableActionParams {
     const type = this.constructor as typeof ESLAlert;
-    return Object.assign({}, type.defaultConfig, type.DEFAULT_PARAMS, this.defaultParams || {}, params || {});
+    return Object.assign({}, type.DEFAULT_PARAMS, this.defaultParams || {}, params || {});
   }
 
   protected override attributeChangedCallback(attrName: string, oldVal: string, newVal: string): void {

--- a/packages/esl/src/esl-event-listener/core/api.ts
+++ b/packages/esl/src/esl-event-listener/core/api.ts
@@ -32,13 +32,6 @@ export class ESLEventUtils {
   public static descriptors = getDescriptors;
 
   /**
-   * Gets auto {@link ESLListenerDescriptorFn}s of the passed object
-   *
-   * @deprecated alias for `descriptors(host, {auto: true})`
-   */
-  public static getAutoDescriptors = (host: object): ESLListenerDescriptorFn[] => getDescriptors(host, {auto: true});
-
-  /**
    * Decorates passed `key` of the `host` as an {@link ESLListenerDescriptorFn} using `desc` meta information
    * @param host - object holder of the function to decorate
    * @param key - string key of the function in holder object

--- a/packages/esl/src/esl-event-listener/core/targets/intersection.event.ts
+++ b/packages/esl/src/esl-event-listener/core/targets/intersection.event.ts
@@ -13,8 +13,6 @@ export class ESLIntersectionEvent extends Event implements IntersectionObserverE
   public static readonly IN = 'intersects:in';
   /** Type of event that will be dispatched on both viewport enter and exit */
   public static readonly TYPE = 'intersects';
-  /** @deprecated use {@link TYPE} instead */
-  public static readonly type = this.TYPE;
 
   public override readonly type: ESLIntersectionEventType;
 

--- a/packages/esl/src/esl-event-listener/core/targets/resize.target.event.ts
+++ b/packages/esl/src/esl-event-listener/core/targets/resize.target.event.ts
@@ -5,8 +5,6 @@ import type {ESLResizeObserverTarget} from './resize.target';
 /** Custom event that {@link ESLResizeObserverTarget} produces */
 export class ESLElementResizeEvent extends UIEvent implements ResizeObserverEntry {
   public static readonly TYPE = 'resize';
-  /** @deprecated Use {@link TYPE} instead */
-  public static readonly type = this.TYPE;
 
   public override readonly type: typeof ESLElementResizeEvent.TYPE;
 

--- a/packages/esl/src/esl-event-listener/core/targets/swipe.target.event.ts
+++ b/packages/esl/src/esl-event-listener/core/targets/swipe.target.event.ts
@@ -32,8 +32,6 @@ export interface ESLSwipeGestureEventInfo {
  */
 export class ESLSwipeGestureEvent extends UIEvent implements ESLSwipeGestureEventInfo {
   public static readonly TYPE = 'swipe';
-  /** @deprecated Use {@link TYPE} instead */
-  public static readonly type = this.TYPE;
 
   public override readonly type: typeof ESLSwipeGestureEvent.TYPE;
 

--- a/packages/esl/src/esl-event-listener/core/targets/wheel.target.event.ts
+++ b/packages/esl/src/esl-event-listener/core/targets/wheel.target.event.ts
@@ -21,8 +21,6 @@ export interface ESLWheelEventInfo {
  */
 export class ESLWheelEvent extends UIEvent implements ESLWheelEventInfo {
   public static readonly TYPE = 'longwheel';
-  /** @deprecated Use {@link TYPE} instead */
-  public static readonly type = this.TYPE;
 
   public override readonly type: typeof ESLWheelEvent.TYPE;
 

--- a/packages/esl/src/esl-media-query/core/common/media-shortcuts.ts
+++ b/packages/esl/src/esl-media-query/core/common/media-shortcuts.ts
@@ -29,7 +29,6 @@ const SHORTCUTS_STORE = Symbol.for('__esl_media_shortcuts');
  *
  * @implements IMediaQueryPreprocessor statically
  */
-@ExportNs('EnvShortcuts')
 @ExportNs('MediaShortcuts')
 export class ESLMediaShortcuts {
   /** Returns shortcuts map, ensures there is a single instance */
@@ -66,24 +65,7 @@ export class ESLMediaShortcuts {
     if (!SHORTCUT_REGEXP.test(match)) return NOT_ALL;
     return this.resolve(match);
   }
-
-  // Legacy support
-  /** @deprecated use `set` method instead (Going to be removed in ESL 6.0.0)*/
-  public static add = ESLMediaShortcuts.set;
-
-  /**
-   * Remove mapping for passed shortcut term.
-   * @deprecated use `ESLEnvShortcuts.set(shortcut, false)` instead (Going to be removed in ESL 6.0.0)
-   */
-  public static remove(shortcut: string): boolean {
-    const contain = this.shortcuts.has(shortcut.toLowerCase());
-    ESLMediaShortcuts.set(shortcut, NOT_ALL);
-    return contain;
-  }
 }
-
-/** @deprecated use `ESLMediaShortcuts` instead (Going to be removed in ESL 6.0.0) */
-export const ESLEnvShortcuts = ESLMediaShortcuts;
 
 // Touch check
 ESLMediaShortcuts.set('touch', isTouchDevice);
@@ -107,8 +89,6 @@ declare global {
     [SHORTCUTS_STORE]: Map<string, MediaQueryStaticCondition>;
   }
   export interface ESLLibrary {
-    /** @deprecated use `ESLMediaShortcuts` instead (Going to be removed in ESL 6.0.0) */
-    EnvShortcuts: typeof ESLMediaShortcuts;
     MediaShortcuts: typeof ESLMediaShortcuts;
   }
 }

--- a/packages/esl/src/esl-utils/async/promise.ts
+++ b/packages/esl/src/esl-utils/async/promise.ts
@@ -45,21 +45,3 @@ export function resolvePromise<T>(arg: T | PromiseLike<T>): Promise<T> {
 export function rejectPromise<T = never>(arg?: T | PromiseLike<T>): Promise<T> {
   return Promise.reject(arg);
 }
-
-/**
- * Promise utils helper class
- * Note: use individual methods in case you need correct "tree shaking"
- * @deprecated use separate function extend
- */
-export abstract class PromiseUtils {
-  static fromTimeout = promisifyTimeout;
-  static fromEvent = promisifyEvent;
-  static fromMarker = promisifyMarker;
-
-  static repeat = repeatSequence;
-  static tryUntil = tryUntil;
-
-  static deferred = createDeferred;
-  static resolve = resolvePromise;
-  static reject = rejectPromise;
-}

--- a/packages/esl/src/esl-utils/dom/rtl.ts
+++ b/packages/esl/src/esl-utils/dom/rtl.ts
@@ -1,23 +1,5 @@
-const DEFAULT_SCROLL_TYPE = 'negative';
-
-/** @deprecated RTL scroll browser behaviors now always returns `negative` value */
-export type ScrollType = typeof DEFAULT_SCROLL_TYPE;
-
 /** Checks if the element in a RTL direction context */
 export const isRTL = (el?: HTMLElement | null): boolean => getComputedStyle(el || document.body).direction === 'rtl';
-
-/** @deprecated scroll type is now consistent and always returns a `negative` value */
-export const testRTLScrollType = (): ScrollType => {
-  return DEFAULT_SCROLL_TYPE;
-};
-
-/** @deprecated scroll type is now consistent and always returns a `negative` value */
-export const RTLScroll = {
-  /** @returns RTL scroll type (lazy, memoized) */
-  get type(): ScrollType {
-    return DEFAULT_SCROLL_TYPE;
-  }
-};
 
 export const normalizeScrollLeft = (el: HTMLElement, value: number | null = null, isRtl: boolean = isRTL(el)): number => {
   value = (value === null) ? el.scrollLeft : value;

--- a/packages/esl/src/esl-utils/environment/device-detector.ts
+++ b/packages/esl/src/esl-utils/environment/device-detector.ts
@@ -1,5 +1,3 @@
-import {ExportNs} from './export-ns';
-
 const {userAgent, vendor, platform} = window.navigator;
 
 // IE Detection
@@ -28,9 +26,6 @@ export const isSafari = isWebkit && /^((?!chrome|android).)*safari/i.test(userAg
 // Blink
 export const isBlink = isWebkit && !isSafari;
 
-/** @deprecated bot detection no longer works (speed bot now has no specific) and supported from ESL side */
-export const isBot = /Chrome-Lighthouse|Google Page Speed Insights/i.test(userAgent);
-
 // Mobile
 export const isAndroid = /Android/i.test(userAgent);
 export const isMobileIOS13 = /* iOS 13+ detection */ (platform === 'MacIntel' && window.navigator.maxTouchPoints > 1);
@@ -53,62 +48,3 @@ export const hasHover = !matchMedia('(hover: none)').matches;
 
 /** true if a user prefers to minimize the amount of non-essential motion */
 export const isReducedMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
-
-/**
- * Device detection utility
- * @readonly
- * @deprecated use separate checks from the same module instead
- */
-@ExportNs('DeviceDetector')
-export abstract class DeviceDetector {
-  // IE Detection
-  public static readonly isTrident = isTrident;
-  public static readonly isIE = isIE;
-
-  // Edge Detection
-  public static readonly isEdgeHTML = isEdgeHTML;
-  public static readonly isBlinkEdge = isBlinkEdge;
-  public static readonly isEdge = isEdge;
-
-  // Gecko
-  public static readonly isGecko = isGecko;
-  public static readonly isFirefox = isFirefox;
-
-  // Opera / Chrome
-  public static readonly isOpera = isOpera;
-  public static readonly isChrome = isChrome;
-
-  // Webkit
-  public static readonly isWebkit = isWebkit;
-
-  // Safari
-  public static readonly isSafari = isSafari;
-
-  // Blink
-  public static readonly isBlink = isBlink;
-
-  // Bot detection
-  public static readonly isBot = isBot;
-
-  // Mobile
-  public static readonly isAndroid = isAndroid;
-  public static readonly isMobileIOS13 = isMobileIOS13;
-  public static readonly isMobileIOS = isMobileIOS;
-  public static readonly isLegacyMobile = isLegacyMobile;
-
-  public static readonly isMobile = isMobile;
-  public static readonly isMobileSafari = isMobileSafari;
-
-  // Touch Detection
-  public static isTouchDevice = isTouchDevice;
-
-  // Hover check
-  // Note: always true for IE
-  public static hasHover = hasHover;
-}
-
-declare global {
-  export interface ESLLibrary {
-    DeviceDetector: typeof DeviceDetector;
-  }
-}

--- a/packages/esl/src/esl-utils/misc.ts
+++ b/packages/esl/src/esl-utils/misc.ts
@@ -1,16 +1,5 @@
 export * as SetUtils from './misc/set';
 
-/** @deprecated `misc/uid` is going to be exported as it is without wrapper object */
-export * as UID from './misc/uid';
-/** @deprecated `misc/array` is going to be exported as it is without wrapper object */
-export * as ArrayUtils from './misc/array';
-/** @deprecated `misc/object` is going to be exported as it is without wrapper object */
-export * as ObjectUtils from './misc/object';
-/** @deprecated `misc/format` is going to be exported as it is without wrapper object */
-export * as FormatUtils from './misc/format';
-/** @deprecated `misc/functions` is going to be exported as it is without wrapper object */
-export * as FunctionUtils from './misc/functions';
-
 export * from './misc/uid';
 export * from './misc/array';
 export * from './misc/object';

--- a/packages/esl/src/esl-utils/misc/array.ts
+++ b/packages/esl/src/esl-utils/misc/array.ts
@@ -10,12 +10,6 @@ export const tuple = <T>(arr: T[]): Tuple<T>[] => arr.reduce((acc: Tuple<T>[], e
   return acc;
 }, []);
 
-/**
- * Flat array - unwraps one level of nested arrays
- * @deprecated use `Array.prototype.flat` instead
- */
-export const flat = <T>(arr: (null | T | T[])[]): T[] => arr.flat(1) as T[];
-
 /** Wraps passed object or primitive to array */
 export const wrap = <T>(arr: undefined | null | T | T[]): T[] => {
   if (arr === undefined || arr === null) return [];

--- a/packages/esl/src/esl-utils/misc/test/array.test.ts
+++ b/packages/esl/src/esl-utils/misc/test/array.test.ts
@@ -1,4 +1,4 @@
-import {flat, range, tuple, uniq, wrap, unwrap, groupBy} from '../array';
+import {range, tuple, uniq, wrap, unwrap, groupBy} from '../array';
 
 describe('misc/array helper tests', () => {
   test('tuple', () => {
@@ -9,17 +9,6 @@ describe('misc/array helper tests', () => {
     expect(tuple([1, 2, 3, 4])).toEqual([[1, 2], [3, 4]]);
     expect(tuple([1, 2, 3, 4, 5])).toEqual([[1, 2], [3, 4], [5]]);
     expect(tuple([1, 2, 3, 4, 5, 6])).toEqual([[1, 2], [3, 4], [5, 6]]);
-  });
-
-  test('flat', () => {
-    expect(flat([])).toEqual([]);
-    expect(flat([0])).toEqual([0]);
-    expect(flat([1])).toEqual([1]);
-    expect(flat([1, 2])).toEqual([1, 2]);
-    expect(flat([1, [2, 3]])).toEqual([1, 2, 3]);
-    expect(flat([[1, 2], [3, 4]])).toEqual([1, 2, 3, 4]);
-    expect(flat([[1], [2, 3, 4], [], [5]])).toEqual([1, 2, 3, 4, 5]);
-    expect(flat([null, 1, 2, 3, [4, 5], null, [6]])).toEqual([null, 1, 2, 3, 4, 5, null, 6]);
   });
 
   test('wrap', () => {

--- a/packages/eslint-config/rules/custom/configs.js
+++ b/packages/eslint-config/rules/custom/configs.js
@@ -7,20 +7,19 @@
  */
 export const configs = [
   {
-    min: '5.13.0',
-    max: '7.0.0',
-    aliases: {
-      ESLAlertShape: 'ESLAlertTagShape',
-      ESLAnimateShape: 'ESLAnimateTagShape',
-      ESLCarouselShape: 'ESLCarouselTagShape',
-      ESLCarouselNavDotsShape: 'ESLCarouselNavDotsTagShape',
-      ESLRandomTextShape: 'ESLRandomTextTagShape'
-    }
-  },
-  {
     min: '5.0.0',
-    max: '7.0.0',
+    max: '6.0.0',
+    aliases: {
+      AlertActionParams: 'ESLAlertActionParams',
+      PanelActionParams: 'ESLPanelActionParams',
+      PopupActionParams: 'ESLPopupActionParams',
+      TooltipActionParams: 'ESLTooltipActionParams',
+      ESLEnvShortcuts: 'ESLMediaShortcuts'
+    },
     staticMembers: {
+      ESLAlert: {
+        defaultConfig: 'DEFAULT_PARAMS'
+      },
       ESLIntersectionEvent: {
         type: 'TYPE'
       },
@@ -32,7 +31,22 @@ export const configs = [
       },
       ESLWheelEvent: {
         type: 'TYPE'
+      },
+      ESLMediaShortcuts: {
+        add: 'set',
+        remove: 'set'
       }
+    }
+  },
+  {
+    min: '5.13.0',
+    max: '7.0.0',
+    aliases: {
+      ESLAlertShape: 'ESLAlertTagShape',
+      ESLAnimateShape: 'ESLAnimateTagShape',
+      ESLCarouselShape: 'ESLCarouselTagShape',
+      ESLCarouselNavDotsShape: 'ESLCarouselNavDotsTagShape',
+      ESLRandomTextShape: 'ESLRandomTextTagShape'
     }
   }
 ];


### PR DESCRIPTION
BREAKING CHANGE: `ESLAlert.defaultConfig` removed (use `ESLAlert.DEFAULT_PARAMS` instead)
BREAKING CHANGE: `ESLIntersectionEvent.type`, `ESLElementResizeEvent.type`, `ESLSwipeGestureEvent.type` and `ESLWheelEvent.type` removed
BREAKING CHANGE: `ESLEventUtils.getAutoDescriptors` removed (use `ESLEventUtils.descriptors(host, {auto: true})` instead)
BREAKING CHANGE: `ESLEnvShortcuts` alias for `ESLMediaShortcuts` removed
BREAKING CHANGE: `ESLMediaShortcuts.add` and `ESLMediaShortcuts.set` removed (use `ESLMediaShortcuts.set` instead)
BREAKING CHANGE: `PromiseUtils` removed, use individual methods instead
BREAKING CHANGE: `RTLScroll`, `ScrollType`, `testRTLScrollType` removed (IE, Edge < 14 are no longer in support list)
BREAKING CHANGE: `isBot` check removed (no longer works)
BREAKING CHANGE: `DeviceDetector` removed, use individual checks instead
BREAKING CHANGE: `flat` removed, use ootb `Array.prototype.flat`
BREAKING CHANGE: `UID`, `ArrayUtils`, `ObjectUtils`, `FormatUtils`, `FunctionUtils` removed, use individual methods of the modules
