### PR TITLE
fix(ui-playground): duplicate theme toggle icon

### DIFF
--- a/packages/ui-playground/src/plugins/settings/settings.tsx
+++ b/packages/ui-playground/src/plugins/settings/settings.tsx
@@ -3,7 +3,6 @@ import {attr, boolAttr, decorate, listen, memoize} from '@exadel/esl/modules/esl
 import {parseBoolean, toBooleanAttribute} from '@exadel/esl/modules/esl-utils/misc/format';
 
 import {UIPPluginPanel} from '../../core/panel/plugin-panel';
-import {ThemeToggleIcon} from '../theme/theme-toggle.icon';
 
 import {UIPDefaults} from '../../core/config/config';
 import {SettingsIcon} from './settings.icon';
@@ -49,7 +48,7 @@ export class UIPSettings extends UIPPluginPanel {
   protected override get $toolbar(): HTMLElement {
     const type = this.constructor as typeof UIPSettings;
     return (<div class={type.is + '-toolbar uip-plugin-header-toolbar'}>
-      {this.themeToggle ? <uip-theme-toggle class={type.is + '-toolbar-option'}><ThemeToggleIcon/></uip-theme-toggle> : ''}
+      {this.themeToggle ? <uip-theme-toggle class={type.is + '-toolbar-option'}></uip-theme-toggle> : ''}
       {this.dirToggle ? <uip-dir-toggle class={type.is + '-toolbar-option'}/> : ''}
     </div>) as HTMLElement;
   }


### PR DESCRIPTION
Closes: #3420

The icon is already appended in UIPThemeSwitcher

<img width="538" height="180" alt="Screenshot from 2025-10-07 18-42-28" src="https://github.com/user-attachments/assets/c4ae2182-9a2e-414e-9a1f-6f35d052866d" />
