### PR TITLE
chore: update Node.js version to 22.x and remove NPM token creation step due to migration to OIDC (Trusted Publishing)

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 env:
-  node-version: 20.x
+  node-version: 22.x
 
 jobs:
   validate-commit:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,7 +12,7 @@ on:
         description: 'Create a pull request to update snapshots on the current branch'
 
 env:
-  node-version: 20.x
+  node-version: 22.x
   DIFF_REPORT_BRANCH: diff-report
 
 concurrency:

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -8,7 +8,7 @@ permissions:
   packages: write
 
 env:
-  node-version: 20.x
+  node-version: 22.x
 
 concurrency:
   group: release-${{ github.ref }}

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -3,12 +3,8 @@ name: Release Handler (NPM)
 on:
   workflow_dispatch:
 
-permissions:
-  contents: write
-  packages: write
-
 env:
-  node-version: 20.x
+  node-version: 22.x
 
 jobs:
   publish:
@@ -37,11 +33,6 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Create NPM Token
-        run: echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Print Environment Info
         run: npx nx report
         shell: bash
@@ -58,5 +49,4 @@ jobs:
         run: npx nx release publish --tag=${{ steps.tag.outputs.tag }}
         shell: bash
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -10,7 +10,7 @@ permissions:
   pull-requests: write
 
 env:
-  node-version: 20.x
+  node-version: 22.x
 
 concurrency:
   group: release-pr-${{ github.ref }}

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  node-version: 20.x
+  node-version: 22.x
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  node-version: 20.x
+  node-version: 22.x
 
 jobs:
   lint:


### PR DESCRIPTION
More on NPM trust Publishing topic - https://gh.io/npm-token-changes