### PR TITLE
fix(esl-popup): fix race condition in ESLPopup when rapidly toggling state

### DIFF
--- a/packages/esl/src/esl-popup/core/esl-popup.ts
+++ b/packages/esl/src/esl-popup/core/esl-popup.ts
@@ -191,8 +191,8 @@ export class ESLPopup extends ESLToggleable {
       this.afterOnHide(params);
     }
 
-    super.onShow(params);
     this._params = copy(params, (key: string) => (this.constructor as typeof ESLPopup).CONFIG_KEYS.includes(key));
+    super.onShow(params);
 
     this.style.visibility = 'hidden'; // eliminates the blinking of the popup at the previous position
 
@@ -322,7 +322,7 @@ export class ESLPopup extends ESLToggleable {
 
   @listen({auto: false, group: 'observer', event: ($popup: ESLPopup) => $popup.REFRESH_EVENT, target: window})
   protected _onRefresh({target}: Event): void {
-    if (!isElement(target)) return;
+    if (!this.open || !isElement(target)) return;
     const {activator, $container} = this;
     if ($container === target || this.contains(target) || isRelativeNode(activator, target)) this._updatePosition();
   }
@@ -396,7 +396,7 @@ export class ESLPopup extends ESLToggleable {
 
   /** Updates position of popup and its arrow */
   protected _updatePosition(): void {
-    if (!this.activator) return;
+    if (!this.activator || !this.open) return;
 
     const {placedAt, popup, arrow} = calcPopupPosition(this.positionConfig);
 


### PR DESCRIPTION
### Problem:
When rapidly opening/closing popup, `TypeError: offsetContainer is not iterable` occurred because `super.onShow()` fired `REFRESH_EVENT` before `_params` were set, causing `config.offsetContainer` to be undefined.

Closes: #3445
