### PR TITLE
[🚀 in site]: improve blogs section of the site #3516

### DIFF
--- a/packages/esl-website/11ty/nav-sort.config.js
+++ b/packages/esl-website/11ty/nav-sort.config.js
@@ -1,0 +1,149 @@
+/**
+ * Separates the list page item from regular navigation items
+ * @param {Array} items - Array of navigation items
+ * @returns {Object} Object with mainItems (regular items) and listPageItem (the list page, if any)
+ */
+function separateListPage(items) {
+  if (!Array.isArray(items)) return { mainItems: items || [], listPageItem: null };
+
+  const listPageItems = items.filter(item => item?.data?.list === true);
+  const listPageItem = listPageItems.length > 0 ? listPageItems[0] : null;
+  const mainItems = items.filter(item => item?.data?.list !== true);
+
+  return { mainItems, listPageItem };
+}
+
+/**
+ * Truncates items list to the specified limit
+ * @param {Array} items - Array of navigation items
+ * @param {number} limit - Maximum number of items to show
+ * @returns {Array} Truncated array of items
+ */
+function truncateItems(items, limit) {
+  if (!Array.isArray(items) || !limit || limit >= items.length) {
+    return items || [];
+  }
+
+  return items.slice(0, limit);
+}
+
+/**
+ * Ensures the active item is visible in the truncated list
+ * @param {Array} items - Full array of navigation items
+ * @param {number} limit - Maximum number of items to show
+ * @param {string} currentUrl - URL of the current page
+ * @returns {Array} Truncated array with active item guaranteed to be visible
+ */
+function ensureActiveItemVisible(items, limit, currentUrl) {
+  if (!Array.isArray(items) || !limit || limit >= items.length) {
+    return items || [];
+  }
+
+  const activeItem = items.find(item => item?.url === currentUrl);
+
+  if (!activeItem) {e
+    return truncateItems(items, limit);
+  }
+
+  const activeIndex = items.indexOf(activeItem);
+  const isActiveInLimited = activeIndex < limit;
+
+  if (isActiveInLimited) {
+    return truncateItems(items, limit);
+  }
+
+  const limited = truncateItems(items, Math.max(limit - 1, 0));
+  limited.push(activeItem);
+
+  return limited;
+}
+
+/**
+ * Processes navigation items based on options
+ * @param {Array} items - Array of navigation items
+ * @param {Object} options - Processing options
+ * @param {string} currentUrl - URL of the current page
+ * @returns {Object} Object with mainItems (items to display) and listPageItem (list page item if enabled)
+ */
+function processNavItems(items, options = {}, currentUrl = '') {
+  if (!Array.isArray(items)) {
+    return { mainItems: [], listPageItem: null };
+  }
+
+  let mainItems = items;
+  let listPageItem = null;
+
+  if (options.showListLink) {
+    const separated = separateListPage(items);
+    mainItems = separated.mainItems;
+    listPageItem = separated.listPageItem;
+  }
+
+  if (options.truncate && options.limit) {
+    if (options.ensureActiveVisible) {
+      mainItems = ensureActiveItemVisible(mainItems, options.limit, currentUrl);
+    } else {
+      mainItems = truncateItems(mainItems, options.limit);
+    }
+  }
+
+  return { mainItems, listPageItem };
+}
+
+/**
+ * Adds computed navigation sort options filter
+ * Reads sortBy, reverse, limit, truncate, and showListLink from frontmatter
+ * and makes them available as navSortOptions for all collections
+ */
+export default (config) => {
+  /**
+   * Computes navigation sort options from an item's data
+   * @param {Object} itemData - The data object from a nav collection item
+   * @returns {Object} navSortOptions object with sortBy, reverse, limit, truncate, showListLink, ensureActiveVisible
+   */
+  config.addFilter('navSortOptions', (itemData) => {
+    if (!itemData) return {};
+
+    const navSortOptions = {};
+
+    if (itemData.sortBy) {
+      navSortOptions.sortBy = Array.isArray(itemData.sortBy)
+        ? itemData.sortBy
+        : [itemData.sortBy];
+    }
+
+    if (itemData.reverse !== undefined) {
+      navSortOptions.reverse = itemData.reverse;
+    }
+
+    if (itemData.limit !== undefined) {
+      navSortOptions.limit = itemData.limit;
+    }
+
+    if (itemData.truncate !== undefined) {
+      navSortOptions.truncate = itemData.truncate;
+    }
+
+    if (itemData.showListLink !== undefined) {
+      navSortOptions.showListLink = itemData.showListLink;
+    }
+
+    if (itemData.ensureActiveVisible !== undefined) {
+      navSortOptions.ensureActiveVisible = itemData.ensureActiveVisible;
+    }
+
+    return navSortOptions;
+  });
+
+  /**
+   * Processes navigation items: separates list page and applies truncation
+   * @param {Array} items - Array of sorted navigation items
+   * @param {Object} options - Options object with truncate, limit, showListLink, ensureActiveVisible
+   * @param {string} currentUrl - Current page URL for active item handling
+   * @returns {Object} Object with mainItems and listPageItem
+   */
+  config.addFilter('processNavItems', (items, options = {}, currentUrl = '') => {
+    return processNavItems(items, options, currentUrl);
+  });
+};
+

--- a/packages/esl-website/11ty/nav-sort.config.js
+++ b/packages/esl-website/11ty/nav-sort.config.js
@@ -41,7 +41,7 @@ function ensureActiveItemVisible(items, limit, currentUrl) {
 
   const activeItem = items.find(item => item?.url === currentUrl);
 
-  if (!activeItem) {e
+  if (!activeItem) {
     return truncateItems(items, limit);
   }
 

--- a/packages/esl-website/11ty/sort.filter.js
+++ b/packages/esl-website/11ty/sort.filter.js
@@ -46,7 +46,9 @@ export default (config) => {
       console.error(`Unexpected values for sort filter: ${values}`);
       return values;
     }
-    const comparers = fields.map(buildComparer);
+    // Handle case where first field is an array (for configurable sorting)
+    const sortFields = fields.length === 1 && Array.isArray(fields[0]) ? fields[0] : fields;
+    const comparers = sortFields.map(buildComparer);
     return [...values].sort(compose(...comparers));
   });
 };

--- a/packages/esl-website/11ty/sort.filter.js
+++ b/packages/esl-website/11ty/sort.filter.js
@@ -46,7 +46,14 @@ export default (config) => {
       console.error(`Unexpected values for sort filter: ${values}`);
       return values;
     }
-    // Handle case where first field is an array (for configurable sorting)
+    /**
+     * Special case: If the filter is called from a template with an array of sort fields,
+     * e.g. {{ collection | sortBy(['date', 'order']) }}, then Eleventy/Nunjucks/Liquid
+     * will pass the array as a single argument, resulting in fields = [ ['date', 'order'] ].
+     * This check unwraps the array so that sortFields is always a flat array of field names.
+     * If multiple fields are passed as separate arguments, e.g. {{ collection | sortBy('date', 'order') }},
+     * then fields = ['date', 'order'] and no unwrapping is needed.
+     */
     const sortFields = fields.length === 1 && Array.isArray(fields[0]) ? fields[0] : fields;
     const comparers = sortFields.map(buildComparer);
     return [...values].sort(compose(...comparers));

--- a/packages/esl-website/views/_includes/navigation/collection-grid.njk
+++ b/packages/esl-website/views/_includes/navigation/collection-grid.njk
@@ -2,7 +2,12 @@
   <link href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@500&display=swap" rel="stylesheet">
 
   <ul class="collection-grid unstyled-list {{ 'collection-grid-column' if options.isList }} {{ options.classes or ''}}">
-    {% for item in collections[collection] | released | exclude('data.hidden') | filter('data.parent', [title, undefined]) | sortBy('order', 'name') %}
+    {%- set sortFields = options.sortBy or ['order', 'name'] -%}
+    {%- set sortedItems = collections[collection] | released | exclude('data.hidden') | filter('data.parent', [title, undefined]) | sortBy(sortFields) -%}
+    {%- if options.reverse -%}
+      {%- set sortedItems = sortedItems | reverse -%}
+    {%- endif -%}
+    {% for item in sortedItems %}
       {% set badgeAllowed = not options.noBadge %}
       {% set isDraft = badgeAllowed and [].concat(item.data.tags).includes('draft') %}
       {% set isNew = badgeAllowed and [].concat(item.data.tags).includes('new') %}

--- a/packages/esl-website/views/_includes/navigation/sidebar-item.njk
+++ b/packages/esl-website/views/_includes/navigation/sidebar-item.njk
@@ -50,7 +50,7 @@
       {%- set seeAllItem = seeAllItems and seeAllItems[0] -%}
       {%- set mainItems = sortedItems | exclude('data.list') -%}
       {# Ensure the current page is visible even if it falls outside the limited slice #}
-      {%- set activeCandidates = sortedItems | exclude('data.list') | filter('url', page.url) -%}
+      {%- set activeCandidates = mainItems | filter('url', page.url) -%}
       {%- set activeItem = activeCandidates and activeCandidates[0] -%}
       {%- set limitedItems = mainItems | limit(opt.limit or mainItems.length) -%}
       {%- set isActiveInLimited = activeItem and (limitedItems | filter('url', activeItem.url) | length) -%}
@@ -71,7 +71,7 @@
 
       {# Render the "see all" page at the end with custom label #}
       {% if seeAllItem %}
-        {{ link(seeAllItem, isDevCollection, opt.seeAllLabel or 'Older articles...') }}
+        {{ link(seeAllItem, isDevCollection, opt.seeAllLabel) }}
       {% endif %}
     {% else %}
       {% for item in sortedItems %}

--- a/packages/esl-website/views/_includes/navigation/sidebar-item.njk
+++ b/packages/esl-website/views/_includes/navigation/sidebar-item.njk
@@ -42,16 +42,36 @@
     <esl-a11y-group targets="::child(li)::find(.sidebar-nav-secondary-link)"></esl-a11y-group>
     {%- set sortFields = opt.sortBy or ['order', 'name'] -%}
     {%- set sortedItems = items | sortBy(sortFields) -%}
-    {%- if opt.reverse -%}
-      {%- set sortedItems = sortedItems | reverse -%}
-    {%- endif -%}
-    {% for item in sortedItems %}
-      {% if item.children.length %}
-        {{ subnavItem(item, isDevCollection, opt) }}
-      {% else %}
-        {{ link(item, isDevCollection) }}
+    {%- if opt.reverse -%}{%- set sortedItems = sortedItems | reverse -%}{%- endif -%}
+
+    {% if opt.listTail %}
+      {# Separate the "see all" page (list page) from regular items #}
+      {%- set seeAllItems = sortedItems | filter('data.list') -%}
+      {%- set seeAllItem = seeAllItems and seeAllItems[0] -%}
+      {%- set mainItems = sortedItems | exclude('data.list') -%}
+      {%- if opt.limit -%}{%- set mainItems = mainItems | limit(opt.limit) -%}{%- endif -%}
+
+      {% for item in mainItems %}
+        {% if item.children.length %}
+          {{ subnavItem(item, isDevCollection, opt) }}
+        {% else %}
+          {{ link(item, isDevCollection) }}
+        {% endif %}
+      {% endfor %}
+
+      {# Render the "see all" page at the end with custom label #}
+      {% if seeAllItem %}
+        {{ link(seeAllItem, isDevCollection, opt.seeAllLabel or 'Older articles...') }}
       {% endif %}
-    {% endfor %}
+    {% else %}
+      {% for item in sortedItems %}
+        {% if item.children.length %}
+          {{ subnavItem(item, isDevCollection, opt) }}
+        {% else %}
+          {{ link(item, isDevCollection) }}
+        {% endif %}
+      {% endfor %}
+    {% endif %}
   </ul>
 {% endmacro %}
 
@@ -85,9 +105,10 @@
   </li>
 {% endmacro %}
 
-{% macro link(item, isDevCollection) %}
+{% macro link(item, isDevCollection, displayName = null) %}
   {% set isActive = page.url === item.url %}
   {% set isDraft = [].concat(item.data.tags).includes('draft') %}
+  {% set itemName = displayName or item.data.name %}
 
   <li class="sidebar-nav-secondary-item {{ 'active' if isActive }}"
       {% if isActive %}aria-selected="true"{% endif %}>
@@ -95,7 +116,7 @@
        {% if isActive %}aria-current="page"{% endif %} {% if isDraft or isDevCollection %}rel="nofollow"{% endif %}
        href="{{ item.url | url }}">
       {{ badgeByTags(item.data.tags, isDraftCollection) }}
-      {{ item.data.name }}
+      {{ itemName }}
     </a>
   </li>
 {% endmacro %}

--- a/packages/esl-website/views/_includes/navigation/sidebar-item.njk
+++ b/packages/esl-website/views/_includes/navigation/sidebar-item.njk
@@ -31,18 +31,23 @@
                {% if isPrimaryActive %}data-open{% endif %}
                group="esl-nav"
                fallback-duration="400">
-      {{ linkList(items, isDevCollection) }}
+      {{ linkList(items, isDevCollection, opt) }}
     </esl-panel>
   </li>
   {% endif %}
 {% endmacro %}
 
-{% macro linkList(items, isDevCollection) %}
+{% macro linkList(items, isDevCollection, opt = {}) %}
   <ul class="sidebar-nav-secondary-list">
     <esl-a11y-group targets="::child(li)::find(.sidebar-nav-secondary-link)"></esl-a11y-group>
-    {% for item in items | sortBy('order', 'name') %}
+    {%- set sortFields = opt.sortBy or ['order', 'name'] -%}
+    {%- set sortedItems = items | sortBy(sortFields) -%}
+    {%- if opt.reverse -%}
+      {%- set sortedItems = sortedItems | reverse -%}
+    {%- endif -%}
+    {% for item in sortedItems %}
       {% if item.children.length %}
-        {{ subnavItem(item, isDevCollection) }}
+        {{ subnavItem(item, isDevCollection, opt) }}
       {% else %}
         {{ link(item, isDevCollection) }}
       {% endif %}
@@ -50,7 +55,7 @@
   </ul>
 {% endmacro %}
 
-{% macro subnavItem(item, isDevCollection) %}
+{% macro subnavItem(item, isDevCollection, opt = {}) %}
   {% set isActive = page.url === item.url %}
   {% set hasActive = functions.isActivePath(page.url, item.url) %}
   {% set isDraft = [].concat(item.data.tags).includes('draft') %}
@@ -75,7 +80,7 @@
     <esl-panel class="sidebar-nav-secondary {{ 'open' if hasActive }}"
                {% if hasActive %}data-open{% endif %}
                fallback-duration="400">
-      {{ linkList(item.children, isDevCollection) }}
+      {{ linkList(item.children, isDevCollection, opt) }}
     </esl-panel>
   </li>
 {% endmacro %}

--- a/packages/esl-website/views/_includes/navigation/sidebar-item.njk
+++ b/packages/esl-website/views/_includes/navigation/sidebar-item.njk
@@ -50,8 +50,17 @@
       {%- set seeAllItem = seeAllItems and seeAllItems[0] -%}
       {%- set mainItems = sortedItems | exclude('data.list') -%}
       {%- if opt.limit -%}{%- set mainItems = mainItems | limit(opt.limit) -%}{%- endif -%}
+      {# Ensure the current page is visible even if it falls outside the limited slice #}
+      {%- set activeCandidates = sortedItems | exclude('data.list') | filter('url', page.url) -%}
+      {%- set activeItem = activeCandidates and activeCandidates[0] -%}
+      {%- set activeInMain = activeItem and (mainItems | filter('url', activeItem.url) | length) -%}
+      {%- set activeBeyond = activeItem and not activeInMain -%}
 
       {% for item in mainItems %}
+        {# If active item is outside the limit, replace the last displayed item with it to keep count #}
+        {% if activeBeyond and loop.last %}
+          {% set item = activeItem %}
+        {% endif %}
         {% if item.children.length %}
           {{ subnavItem(item, isDevCollection, opt) }}
         {% else %}

--- a/packages/esl-website/views/_includes/navigation/sidebar-item.njk
+++ b/packages/esl-website/views/_includes/navigation/sidebar-item.njk
@@ -44,43 +44,23 @@
     {%- set sortedItems = items | sortBy(sortFields) -%}
     {%- if opt.reverse -%}{%- set sortedItems = sortedItems | reverse -%}{%- endif -%}
 
-    {% if opt.listTail %}
-      {# Separate the "see all" page (list page) from regular items #}
-      {%- set seeAllItems = sortedItems | filter('data.list') -%}
-      {%- set seeAllItem = seeAllItems and seeAllItems[0] -%}
-      {%- set mainItems = sortedItems | exclude('data.list') -%}
-      {# Ensure the current page is visible even if it falls outside the limited slice #}
-      {%- set activeCandidates = mainItems | filter('url', page.url) -%}
-      {%- set activeItem = activeCandidates and activeCandidates[0] -%}
-      {%- set limitedItems = mainItems | limit(opt.limit or mainItems.length) -%}
-      {%- set isActiveInLimited = activeItem and (limitedItems | filter('url', activeItem.url) | length) -%}
-      {%- set shouldReplaceLast = activeItem and not isActiveInLimited and opt.limit and limitedItems.length >= opt.limit -%}
+    {# Process items: separate list page and apply truncation #}
+    {%- set processed = sortedItems | processNavItems(opt, page.url) -%}
+    {%- set mainItems = processed.mainItems -%}
+    {%- set listPageItem = processed.listPageItem -%}
 
-      {% for item in limitedItems %}
-        {% set itemToRender = item %}
-        {# If active item is beyond limit, replace the last displayed item with it to maintain count #}
-        {% if shouldReplaceLast and loop.last %}
-          {% set itemToRender = activeItem %}
-        {% endif %}
-        {% if itemToRender.children.length %}
-          {{ subnavItem(itemToRender, isDevCollection, opt) }}
-        {% else %}
-          {{ link(itemToRender, isDevCollection) }}
-        {% endif %}
-      {% endfor %}
-
-      {# Render the "see all" page at the end with custom label #}
-      {% if seeAllItem %}
-        {{ link(seeAllItem, isDevCollection, opt.seeAllLabel) }}
+    {# Render main items #}
+    {% for item in mainItems %}
+      {% if item.children.length %}
+        {{ subnavItem(item, isDevCollection, opt) }}
+      {% else %}
+        {{ link(item, isDevCollection) }}
       {% endif %}
-    {% else %}
-      {% for item in sortedItems %}
-        {% if item.children.length %}
-          {{ subnavItem(item, isDevCollection, opt) }}
-        {% else %}
-          {{ link(item, isDevCollection) }}
-        {% endif %}
-      {% endfor %}
+    {% endfor %}
+
+    {# Render the list page link at the end if enabled #}
+    {% if listPageItem %}
+      {{ link(listPageItem, isDevCollection, listPageItem.data.name) }}
     {% endif %}
   </ul>
 {% endmacro %}

--- a/packages/esl-website/views/_includes/navigation/sidebar-item.njk
+++ b/packages/esl-website/views/_includes/navigation/sidebar-item.njk
@@ -49,22 +49,23 @@
       {%- set seeAllItems = sortedItems | filter('data.list') -%}
       {%- set seeAllItem = seeAllItems and seeAllItems[0] -%}
       {%- set mainItems = sortedItems | exclude('data.list') -%}
-      {%- if opt.limit -%}{%- set mainItems = mainItems | limit(opt.limit) -%}{%- endif -%}
       {# Ensure the current page is visible even if it falls outside the limited slice #}
       {%- set activeCandidates = sortedItems | exclude('data.list') | filter('url', page.url) -%}
       {%- set activeItem = activeCandidates and activeCandidates[0] -%}
-      {%- set activeInMain = activeItem and (mainItems | filter('url', activeItem.url) | length) -%}
-      {%- set activeBeyond = activeItem and not activeInMain -%}
+      {%- set limitedItems = mainItems | limit(opt.limit or mainItems.length) -%}
+      {%- set isActiveInLimited = activeItem and (limitedItems | filter('url', activeItem.url) | length) -%}
+      {%- set shouldReplaceLast = activeItem and not isActiveInLimited and opt.limit and limitedItems.length >= opt.limit -%}
 
-      {% for item in mainItems %}
-        {# If active item is outside the limit, replace the last displayed item with it to keep count #}
-        {% if activeBeyond and loop.last %}
-          {% set item = activeItem %}
+      {% for item in limitedItems %}
+        {% set itemToRender = item %}
+        {# If active item is beyond limit, replace the last displayed item with it to maintain count #}
+        {% if shouldReplaceLast and loop.last %}
+          {% set itemToRender = activeItem %}
         {% endif %}
-        {% if item.children.length %}
-          {{ subnavItem(item, isDevCollection, opt) }}
+        {% if itemToRender.children.length %}
+          {{ subnavItem(itemToRender, isDevCollection, opt) }}
         {% else %}
-          {{ link(item, isDevCollection) }}
+          {{ link(itemToRender, isDevCollection) }}
         {% endif %}
       {% endfor %}
 

--- a/packages/esl-website/views/_includes/navigation/sidebar.njk
+++ b/packages/esl-website/views/_includes/navigation/sidebar.njk
@@ -29,7 +29,7 @@
           {% set isActive = env.isDev or functions.isActivePath(page.url, item.data.collection) %}
           {% set navSortOptions = {} %}
           {% if item.data.collection == 'blogs' %}
-            {% set navSortOptions = {sortBy: ['date', 'name'], reverse: true} %}
+            {% set navSortOptions = {sortBy: ['date', 'name'], reverse: true, limit: 10, listTail: true, seeAllLabel: 'Older articles...'} %}
           {% endif %}
 
           {% if isNoEmpty or isActive %}

--- a/packages/esl-website/views/_includes/navigation/sidebar.njk
+++ b/packages/esl-website/views/_includes/navigation/sidebar.njk
@@ -27,10 +27,14 @@
         {% for item in collections.nav | sortBy('order') %}
           {% set isNoEmpty = collections[item.data.collection] | releasedOrActive(page.url) | exclude('data.collection') | length %}
           {% set isActive = env.isDev or functions.isActivePath(page.url, item.data.collection) %}
+          {% set navSortOptions = {} %}
+          {% if item.data.collection == 'blogs' %}
+            {% set navSortOptions = {sortBy: ['date', 'name'], reverse: true} %}
+          {% endif %}
 
           {% if isNoEmpty or isActive %}
             {% if item.data.groupStart %} <hr class="sidebar-hr"/> {% endif %}
-            {{ navItem (item.data.title, item.data.collection, item.data.icon) }}
+            {{ navItem (item.data.title, item.data.collection, item.data.icon, navSortOptions) }}
           {% endif %}
         {% endfor %}
 

--- a/packages/esl-website/views/_includes/navigation/sidebar.njk
+++ b/packages/esl-website/views/_includes/navigation/sidebar.njk
@@ -27,10 +27,7 @@
         {% for item in collections.nav | sortBy('order') %}
           {% set isNoEmpty = collections[item.data.collection] | releasedOrActive(page.url) | exclude('data.collection') | length %}
           {% set isActive = env.isDev or functions.isActivePath(page.url, item.data.collection) %}
-          {% set navSortOptions = {} %}
-          {% if item.data.collection == 'blogs' %}
-            {% set navSortOptions = {sortBy: ['date', 'name'], reverse: true, limit: 10, listTail: true, seeAllLabel: 'Older articles...'} %}
-          {% endif %}
+          {% set navSortOptions = item.data | navSortOptions %}
 
           {% if isNoEmpty or isActive %}
             {% if item.data.groupStart %} <hr class="sidebar-hr"/> {% endif %}

--- a/packages/esl-website/views/_layouts/collection-grid.njk
+++ b/packages/esl-website/views/_layouts/collection-grid.njk
@@ -5,4 +5,4 @@ banner:
 ---
 
 {% from 'navigation/collection-grid.njk' import grid with context %}
-{{ grid(collection, {isList: list, classes: 'collection-grid-bg-white'}) }}
+{{ grid(collection, {isList: list, classes: 'collection-grid-bg-white', sortBy: sortBy, reverse: reverse}) }}

--- a/packages/esl-website/views/blogs/index.njk
+++ b/packages/esl-website/views/blogs/index.njk
@@ -9,4 +9,6 @@ list: true
 tags: [nav, blogs]
 groupStart: true
 icon: sidebar/blogs.svg
+sortBy: [date, name]
+reverse: true
 ---

--- a/packages/esl-website/views/blogs/index.njk
+++ b/packages/esl-website/views/blogs/index.njk
@@ -1,7 +1,7 @@
 ---
 layout: collection-grid
 title: Blogs
-name: See All
+name: Older articles...
 order: 11
 collection: blogs
 hidden: true

--- a/packages/esl-website/views/blogs/index.njk
+++ b/packages/esl-website/views/blogs/index.njk
@@ -11,4 +11,8 @@ groupStart: true
 icon: sidebar/blogs.svg
 sortBy: [date, name]
 reverse: true
+limit: 10
+truncate: true
+showListLink: true
+ensureActiveVisible: true
 ---


### PR DESCRIPTION
This PR refers to https://github.com/exadel-inc/esl/issues/3516

Main changes: 
- Made blog collection grid and sidebar sorting configurable via options; blogs now sort by date desc with reverse support.
- Added sidebar handling for blogs to keep only the latest 10 items plus the list page, rename the list page link to “Older articles...”, and ensure the active blog is shown even if older (replacing the last visible slot).
- Applied blog-page title change from “See All” to “Older articles...”.