### PR TITLE
feat(esl-media): add support extended format for start-time

### DIFF
--- a/packages/esl/src/esl-media/README.md
+++ b/packages/esl/src/esl-media/README.md
@@ -141,7 +141,7 @@ Also, ESLMedia provides attributes to reflect media state and additional classes
     Independent of the lazy state, use `ready-class` if you are interested in the final state of component.
  - `load-condition-class-target` (optional) - [ESLTraversingQuery](../esl-traversing-query/README.md) to define a target for `load-condition-class`
 
- - `start-time` - attribute that allows a user to start viewing a video from a specific time offset. The value is simple time in seconds. By default, it is undefined which means to start from the beginning.
+ - `start-time` - attribute that specifies the time offset from which the video should begin playing. Accepts either a number in seconds or a time string matching the pattern `{hours}h{minutes}m{seconds}s` where any component can be omitted (e.g., "2m3s", "45s", "4h3s", "5m"). If not specified, the video starts from the beginning.
 *(note: that feature doesn't work for Abstract Iframe provider, also doesn't work for HTMLAudio and HTMLVideo providers in case when Web-server when hosted resource doesn't support ['Accept-Ranges' HTTP response marker](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Ranges))*
  - `focusable` (boolean) - marker that allows the video to be focused by keyboard navigation. By default, the video is focusable if `controls` are enabled.
 

--- a/packages/esl/src/esl-media/core/esl-media.shape.ts
+++ b/packages/esl/src/esl-media/core/esl-media.shape.ts
@@ -42,7 +42,7 @@ export type ESLMediaTagShape = ({
   /** Allow play media inline */
   'playsinline'?: boolean;
   /** Allows to start viewing a resource from a specific time offset */
-  'start-time'?: number;
+  'start-time'?: number | string;
 
   /** Optional BC provider player id */
   'data-player-id'?: string;

--- a/packages/esl/src/esl-media/core/esl-media.ts
+++ b/packages/esl/src/esl-media/core/esl-media.ts
@@ -6,7 +6,7 @@ import {PAUSE, SPACE} from '../../esl-utils/dom/keys';
 import {isInViewport} from '../../esl-utils/dom/visible';
 import {attr, boolAttr, listen, memoize, prop} from '../../esl-utils/decorators';
 import {debounce} from '../../esl-utils/async';
-import {parseAspectRatio, parseBoolean, parseLazyAttr} from '../../esl-utils/misc/format';
+import {parseAspectRatio, parseBoolean, parseLazyAttr, parseTimeSeconds} from '../../esl-utils/misc/format';
 
 import {ESLMediaQuery} from '../../esl-media-query/core';
 import {ESLResizeObserverTarget} from '../../esl-event-listener/core';
@@ -120,7 +120,7 @@ export class ESLMedia extends ESLBaseElement {
   /** Allows play resource only in viewport area */
   @attr({parser: parsePlayInViewportAttr}) public playInViewport: 'restart' | boolean;
   /** Allows to start viewing a resource from a specific time offset. */
-  @attr({defaultValue: 0, parser: parseInt}) public startTime: number;
+  @attr({defaultValue: 0, parser: parseTimeSeconds}) public startTime: number;
   /** Allows player to accept focus */
   @attr({
     parser: parseBoolean,

--- a/packages/esl/src/esl-utils/misc/format/test/time.test.ts
+++ b/packages/esl/src/esl-utils/misc/format/test/time.test.ts
@@ -1,4 +1,4 @@
-import {parseCSSTime, parseCSSTimeSet, parseTime} from '../time';
+import {parseCSSTime, parseCSSTimeSet, parseTime, parseTimeSeconds} from '../time';
 
 describe('misc/format - time formatters test', () => {
   describe('parseTime', () => {
@@ -12,7 +12,6 @@ describe('misc/format - time formatters test', () => {
       // Non-integer
       ['.3s', 300],
       ['.124s', 124],
-      ['.3ms', 0.3],
       // Negative integer
       ['-456ms', -456],
       // Exclusion
@@ -22,17 +21,41 @@ describe('misc/format - time formatters test', () => {
       ['14S', 14000],
       // Zero with leading +/-
       ['+0s', 0],
-      ['-0ms', -0],
       // Digits without unit should be parsed as milliseconds
       ['0', 0],
       ['100', 100],
+      [123, 123],
       // Leading zeros
       ['012s', 12000],
       ['0350ms', 350],
       // Empty string
       ['', 0],
       // Extra dot
-      ['350.s', 350000]
+      ['350.s', 350000],
+
+      // Full formats
+      ['2h3m5s300ms', 7385300],
+      ['0h0m0s0ms', 0],
+      ['2h3m5s', 7385000],
+      ['2h3m300ms', 7380300],
+      ['2h5s300ms', 7205300],
+      ['3m5s300ms', 185300],
+
+      ['3s', 3000],
+      ['3.5s', 3500],
+      ['3m', 180000],
+      ['3.5m', 210000],
+      ['3h', 10800000],
+      ['3.5h', 12600000],
+
+      ['5s300ms', 5300],
+      ['3m300ms', 180300],
+      ['2h300ms', 7200300],
+      ['3m5s', 185000],
+      ['2h5s', 7205000],
+      ['2h3m', 7380000],
+
+      ['+2h-1m-3s+500ms', 7137500],
     ])(
       'valid time = %s parsed as %s',
       (time: string, result: number) => expect(parseTime(time)).toBe(result)
@@ -48,7 +71,16 @@ describe('misc/format - time formatters test', () => {
       'abc',
       '-',
       'a',
-      // CSS time supports only seconds and milliseconds
+      '3.5ms',
+      '++5s',
+      '+-5s',
+      '-+5s',
+      '--5s',
+      '-.-5s',
+      '3.5.2s',
+      '2-3s',
+      '2-s',
+      '1h2m3s4ms5',
       '4min'
     ])(
       'invalid time = %p parsed as NaN',
@@ -67,15 +99,13 @@ describe('misc/format - time formatters test', () => {
       // Non-integer
       ['.3s', 300],
       ['.124s', 124],
-      ['.3ms', 0.3],
       // Negative integer
       ['-456ms', -456],
       // Case insensitive
       ['14mS', 14],
       ['14S', 14000],
       // Zero with leading +/-
-      ['+0s', 0],
-      ['-0ms', -0]
+      ['+0s', 0]
     ])(
       'valid time = %s parsed as %s',
       (time: string, result: number) => expect(parseCSSTime(time)).toBe(result)
@@ -111,6 +141,33 @@ describe('misc/format - time formatters test', () => {
     ])(
       'time = %p',
       (time, num) => expect(parseCSSTimeSet.apply(null, time)).toStrictEqual(num)
+    );
+  });
+
+  describe('parseTimeSeconds', () => {
+    test.each([
+      [0, 0],
+      [3, 3],
+      [3.5, 3],
+      ['30s', 30],
+      ['3.5s', 3],
+      ['2.51m', 150],
+      ['3s700ms', 3],
+      ['2h3s700ms', 7203],
+      ['0s', 0],
+    ])(
+      'time = %p',
+      (time, num) => expect(parseTimeSeconds(time)).toStrictEqual(num)
+    );
+
+    test.each([
+      [null],
+      ['m3s'],
+      ['3s5m'],
+      [''],
+    ])(
+      'invalid time = %p is 0',
+      (time) => expect(parseTimeSeconds(time)).toStrictEqual(0)
     );
   });
 });

--- a/packages/esl/src/esl-utils/misc/format/time.ts
+++ b/packages/esl/src/esl-utils/misc/format/time.ts
@@ -1,17 +1,27 @@
+const MS_IN_S = 1000;
+const MS_IN_M = 60 * MS_IN_S;
+const MS_IN_H = 60 * MS_IN_M;
+const TIME_PATTERN = /^([+-]?(?:\d+(?:\.\d*)?|\.\d+)h)?([+-]?(?:\d+(?:\.\d*)?|\.\d+)m)?([+-]?(?:\d+(?:\.\d*)?|\.\d+)s)?([+-]?\d+ms)?$/; // ##h##m##s##ms
+const TIME_UNITS = [MS_IN_H, MS_IN_M, MS_IN_S, 1] as const;
+
 /**
- * Parses time string ([CSS style](https://developer.mozilla.org/en-US/docs/Web/CSS/time))
- * Less strict than CSS spec, allows empty string, numbers without units, ending dot.
+ * Parses time string
+ * Less strict than CSS spec, allows empty string, numbers without units, ending dot, hours, minutes etc.
  * Note: literal `none` is treated as `0`.
  * @example
- * `.3s`, `4.5s`, `1000ms`
+ * `.3s`, `4.5s`, `1000ms`, `700`, `1h20m30s`, `2h`, `5m`, `25m1s`, `2h10s`, `none`
  * @returns number - time in milliseconds
  */
 export function parseTime(timeStr: number | string): number {
   const str = String(timeStr).trim().toLowerCase();
   if (str === 'none') return 0;
-  if (str.endsWith('ms')) return parseFloat(str.slice(0, -2));
-  if (str.endsWith('s')) return parseFloat(str.slice(0, -1)) * 1000;
-  return +str; // Empty string treated as 0, numbers without units treated as milliseconds
+  const ms = +str;
+  if (!isNaN(ms)) return ms; // Empty string treated as 0, numbers without units treated as milliseconds
+
+  const parsed = str.match(TIME_PATTERN);
+  if (!parsed) return NaN; // Invalid format
+  return TIME_UNITS.reduce(
+    (time, size, index) => time + (parseFloat(parsed[index + 1] || '0') * size), 0);
 }
 
 /**
@@ -29,3 +39,21 @@ export const parseCSSTime = (timeStr: string): number => /(\d*\.?\d+)(ms|s)/i.te
 export function parseCSSTimeSet(timeStr: string): number[] {
   return timeStr.split(',').map((timeSubstr) => parseCSSTime(timeSubstr));
 }
+
+/**
+ * Converts time value to seconds
+ * @example
+ * null => 0
+ * '3' => 3
+ * `.3s` => 0
+ * `4.5s` => 4
+ * `1000ms` => 1
+ * `2m3s` => 123
+ * @param value
+ */
+export const parseTimeSeconds = (value: number | string | null): number => {
+  if (!value) return 0;
+  const num = +value;
+  if (!isNaN(num)) return Math.floor(num);
+  return Math.floor(parseTime(value) / MS_IN_S) || 0;
+};


### PR DESCRIPTION
Closes: [#3561](https://github.com/exadel-inc/esl/issues/3561)

- I have updated the documentation
- I have added tests to cover my changes. (Unit tests are strongly advisable for changes under `esl-utils` scope