### PR TITLE
fix(esl-footnotes): add dynamic updates for esl-note-ignore mixin via lifecycle hooks

### DIFF
--- a/packages/esl/src/esl-footnotes/core/esl-note-ignore.ts
+++ b/packages/esl/src/esl-footnotes/core/esl-note-ignore.ts
@@ -12,9 +12,24 @@ export class ESLNoteIgnore extends ESLMixinElement {
   /** Selector to find all dependent ESLNote elements */
   @prop('esl-note') protected noteSelector: string;
 
+  public override connectedCallback(): void {
+    super.connectedCallback();
+    this.updateChildNotes();
+  }
+
+  public override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.updateChildNotes();
+  }
+
   /** Callback to handle changing of additional attributes */
   public override attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null): void {
     if (oldValue === newValue) return;
+    this.updateChildNotes();
+  }
+
+  /** Updates ignored query for all child notes */
+  protected updateChildNotes(): void {
     [...this.$host.querySelectorAll<ESLNote>(this.noteSelector)].forEach(($note) => $note.updateIgnoredQuery());
   }
 }


### PR DESCRIPTION
Here's what was done:

 - logic for updating child notes has been moved to a separate method updateChildNotes
 - added connectedCallback - notes are now updated immediately when the mixin is connected
 - added disconnectedCallback - notes are updated when the mixin is disconnected (so they are no longer ignored).

Closes: #3578 
