### PR TITLE
fix(esl-footnotes): refine initialization on esl-note-ignore when connecting or disconnecting

### DIFF
--- a/packages/esl/src/esl-footnotes/core/esl-note-ignore.ts
+++ b/packages/esl/src/esl-footnotes/core/esl-note-ignore.ts
@@ -19,7 +19,7 @@ export class ESLNoteIgnore extends ESLMixinElement {
 
   public override connectedCallback(): void {
     super.connectedCallback();
-    customElements.whenDefined(this.noteTag).then(() => this.updateChildNotes());
+    this.updateChildNotes();
   }
 
   public override disconnectedCallback(): void {

--- a/packages/esl/src/esl-footnotes/core/esl-note.ts
+++ b/packages/esl/src/esl-footnotes/core/esl-note.ts
@@ -131,6 +131,7 @@ export class ESLNote extends ESLBaseTrigger {
 
   /** Revises the settings for ignoring the note */
   public updateIgnoredQuery(): void {
+    if (!this.connected) return;
     memoize.clear(this, 'queryToIgnore');
     this.$$on(this._onIgnoreConditionChange);
     this._onIgnoreConditionChange();


### PR DESCRIPTION
Refine ESLNoteIgnore implementation:

- BREAKING CHANGES: rename `noteSelector` property to `noteTag`
- add `isNote` type guard for safer element filtering
- update `updateChildNotes` to utilize the new property and type check