### PR TITLE
fix(esl-toggleable): fix ESLToggleableManager interface

### DIFF
--- a/packages/esl/src/esl-toggleable/core.ts
+++ b/packages/esl/src/esl-toggleable/core.ts
@@ -3,5 +3,6 @@ export type {ESLToggleableDispatcherTagShape} from './core/esl-toggleable-dispat
 
 export * from './core/esl-toggleable';
 export * from './core/esl-toggleable-manager';
+export * from './core/esl-toggleable-manager.types';
 export * from './core/esl-toggleable-dispatcher';
 export * from './core/esl-toggleable-placeholder';

--- a/packages/esl/src/esl-toggleable/core/esl-toggleable-manager.ts
+++ b/packages/esl/src/esl-toggleable/core/esl-toggleable-manager.ts
@@ -6,13 +6,11 @@ import {TAB} from '../../esl-utils/dom/keys';
 import {handleFocusChain} from '../../esl-utils/dom/focus';
 
 import type {ESLToggleable} from './esl-toggleable';
+import type {ESLToggleableManager} from './esl-toggleable-manager.types';
 
-/** Focus flow behaviors */
-export type ESLA11yType = 'none' | 'autofocus' | 'popup' | 'dialog' | 'modal';
-
-let instance: ESLToggleableManager;
+let instance: ESLToggleableManagerDefault;
 /** Focus manager for toggleable instances. Singleton. */
-export class ESLToggleableManager {
+export class ESLToggleableManagerDefault implements ESLToggleableManager {
   /** Active toggleable */
   protected active = new Set<ESLToggleable>();
   /** Focus scopes stack. Manager observes only top level scope. */

--- a/packages/esl/src/esl-toggleable/core/esl-toggleable-manager.types.ts
+++ b/packages/esl/src/esl-toggleable/core/esl-toggleable-manager.types.ts
@@ -1,0 +1,24 @@
+import type {ESLToggleable} from './esl-toggleable';
+
+/** Focus flow behaviors */
+export type ESLA11yType = 'none' | 'autofocus' | 'popup' | 'dialog' | 'modal';
+
+/**
+ * Manager interface for controlling focus scope and lifecycle of {@link ESLToggleable} elements.
+ *
+ * Responsibilities:
+ * - Maintains a stack of active toggleable elements
+ * - Manages focus transitions and keyboard navigation (Tab key handling)
+ * - Tracks relationships between related toggleables (e.g., nested popups)
+ * - Handles outside interaction detection for auto-closing behavior
+ */
+export interface ESLToggleableManager {
+  /** Changes focus scope to the specified element. Previous scope saved in the stack. */
+  attach(element: ESLToggleable): void;
+
+  /** Removes the specified element from the known focus scopes. */
+  detach(element: ESLToggleable, fallback?: HTMLElement | null): void;
+
+  /** Checks if the element is related to the specified toggleable open chain */
+  isRelates(element: HTMLElement, related: ESLToggleable): boolean;
+}

--- a/packages/esl/src/esl-toggleable/core/esl-toggleable.shape.ts
+++ b/packages/esl/src/esl-toggleable/core/esl-toggleable.shape.ts
@@ -1,6 +1,6 @@
 import type {ESLBaseElementShape} from '../../esl-base-element/core/esl-base-element.shape';
 import type {ESLToggleable} from './esl-toggleable';
-import type {ESLA11yType} from './esl-toggleable-manager';
+import type {ESLA11yType} from './esl-toggleable-manager.types';
 
 /**
  * Tag declaration interface of {@link ESLToggleable} element

--- a/packages/esl/src/esl-toggleable/core/esl-toggleable.ts
+++ b/packages/esl/src/esl-toggleable/core/esl-toggleable.ts
@@ -10,10 +10,10 @@ import {DelayedTask} from '../../esl-utils/async/delayed-task';
 import {ESLBaseElement} from '../../esl-base-element/core';
 import {findParent, isMatches} from '../../esl-utils/dom/traversing';
 import {getKeyboardFocusableElements} from '../../esl-utils/dom/focus';
-import {ESLToggleableManager} from './esl-toggleable-manager';
+import {ESLToggleableManagerDefault} from './esl-toggleable-manager';
 
-import type {ESLA11yType} from './esl-toggleable-manager';
 import type {DelegatedEvent} from '../../esl-event-listener/core/types';
+import type {ESLToggleableManager, ESLA11yType} from './esl-toggleable-manager.types';
 
 /** Default Toggleable action params type definition */
 export interface ESLToggleableActionParams {
@@ -308,7 +308,7 @@ export class ESLToggleable extends ESLBaseElement {
 
   /** Focus manager instance */
   public get manager(): ESLToggleableManager {
-    return new ESLToggleableManager();
+    return new ESLToggleableManagerDefault();
   }
 
   /** Last component that has activated the element. Uses {@link ESLToggleableActionParams.activator}*/


### PR DESCRIPTION
BREAKING CHANGE: `ESLToggleableManager` instance renamed to `ESLToggleableManagerDefault`