### PR TITLE
chore(site): resolve watch mode issues for njk, less, and md file changes

### DIFF
--- a/packages/esl-website/11ty/watch.targets.js
+++ b/packages/esl-website/11ty/watch.targets.js
@@ -19,4 +19,11 @@ export default (config) => {
 
   // Set a delay for the build process
   config.setWatchThrottleWaitTime(500);
+
+  // Disable template cache in serve mode to fix stale content on njk changes.
+  // The ../../ watch targets cause chokidar CWD remap that breaks Eleventy's
+  // internal cache invalidation (path mismatch between watcher and template inputPath).
+  if (process.argv.includes('--serve')) {
+    config.setUseTemplateCache(false);
+  }
 };

--- a/packages/esl-website/project.json
+++ b/packages/esl-website/project.json
@@ -175,7 +175,7 @@
           "\"packages/esl/modules/.less.done\"",
           "\"packages/ui-playground/dist/.less.done\"",
           "\"packages/esl-website/src/**/*.less\"",
-          "-c \"nx run esl-website:build:less:only\""
+          "-c \"nx run esl-website:build:less:only --skip-nx-cache\""
         ]
       }
     },

--- a/packages/esl/project.json
+++ b/packages/esl/project.json
@@ -88,7 +88,7 @@
     "watch:less": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "chokidar \"src/**/*.less\" -c \"nx run esl:build:less\"",
+        "command": "chokidar \"src/**/*.less\" -c \"nx run esl:build:less --skip-nx-cache\"",
         "cwd": "packages/esl"
       }
     },
@@ -115,7 +115,7 @@
     "watch:docs": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "chokidar \"src/**/*.md\" -c \"nx run esl:build:docs\"",
+        "command": "chokidar \"src/**/*.md\" -c \"nx run esl:build:docs --skip-nx-cache\"",
         "cwd": "packages/esl"
       }
     },

--- a/packages/ui-playground/project.json
+++ b/packages/ui-playground/project.json
@@ -89,7 +89,7 @@
     "watch:less": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "chokidar \"src/**/*.less\" -c \"nx run uip:build:less\"",
+        "command": "chokidar \"src/**/*.less\" -c \"nx run uip:build:less --skip-nx-cache\"",
         "cwd": "packages/ui-playground"
       }
     },
@@ -116,7 +116,7 @@
     "watch:docs": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "chokidar \"src/**/*.md\" -c \"nx run uip:build:docs\"",
+        "command": "chokidar \"src/**/*.md\" -c \"nx run uip:build:docs --skip-nx-cache\"",
         "cwd": "packages/ui-playground"
       }
     },


### PR DESCRIPTION
- disable template cache in serve mode to fix stale njk content
- add --skip-nx-cache to chokidar watchers to prevent cached no-ops