### PR TITLE
chore: fix major issues with dev flow (watch, dependencies, legacy fixes)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "less": "4.6.6",
         "less-plugin-clean-css": "^1.6.0",
         "lint-staged": "^17.0.7",
+        "nodemon": "^3.1.14",
         "postcss": "^8.5.15",
         "postcss-less": "^6.0.0",
         "rimraf": "^6.1.3",
@@ -10147,6 +10148,13 @@
         "node": ">= 4"
       }
     },
+    "node_modules/ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/image-size": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
@@ -12133,6 +12141,58 @@
         "esm-import-transformer": "^3.0.3"
       }
     },
+    "node_modules/nodemon": {
+      "version": "3.1.14",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.14.tgz",
+      "integrity": "sha512-jakjZi93UtB3jHMWsXL68FXSAosbLfY0In5gtKq3niLSkrWznrVBzXFNOEMJUfc9+Ke7SHWoAZsiMkNP3vq6Jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "debug": "^4",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^10.2.1",
+        "pstree.remy": "^1.1.8",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5"
+      },
+      "bin": {
+        "nodemon": "bin/nodemon.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "node_modules/nodemon/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/nodemon/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -13362,6 +13422,13 @@
       "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
       "license": "MIT"
     },
+    "node_modules/pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -14192,6 +14259,19 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
+    },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/slash": {
       "version": "5.1.0",
@@ -15424,6 +15504,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "7.25.0",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "less": "4.6.6",
     "less-plugin-clean-css": "^1.6.0",
     "lint-staged": "^17.0.7",
+    "nodemon": "^3.1.14",
     "postcss": "^8.5.15",
     "postcss-less": "^6.0.0",
     "rimraf": "^6.1.3",

--- a/packages/esl-website/.eleventy.js
+++ b/packages/esl-website/.eleventy.js
@@ -27,9 +27,11 @@ export default async (config) => {
     '../../skills': 'skills'
   });
 
+  // Disable template cache to fix stale content on NJK changes
+  config.setUseTemplateCache(false);
+
   config.setServerOptions({
     port: process.env.PORT || 3005,
-    domDiff: false, // Disabled until https://github.com/11ty/eleventy-dev-server/issues/77 is fixed
     watch: [
       'dist/bundles/*.js',
       'dist/bundles/*.css'

--- a/packages/esl-website/11ty/watch.targets.js
+++ b/packages/esl-website/11ty/watch.targets.js
@@ -19,7 +19,4 @@ export default (config) => {
 
   // Set a delay for the build process
   config.setWatchThrottleWaitTime(500);
-
-  // Disable template cache to fix stale content on NJK changes
-  config.setUseTemplateCache(false);
 };

--- a/packages/esl-website/project.json
+++ b/packages/esl-website/project.json
@@ -170,12 +170,15 @@
     "watch:less": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "chokidar",
+        "command": "nodemon",
         "args": [
-          "\"packages/esl/modules/.less.done\"",
-          "\"packages/ui-playground/dist/.less.done\"",
-          "\"packages/esl-website/src/**/*.less\"",
-          "-c \"nx run esl-website:build:less:only\""
+          "--on-change-only",
+          "--watch \"packages/esl/modules\"",
+          "--watch \"packages/ui-playground/dist\"",
+          "--watch \"packages/esl-website/src\"",
+          "--ext css,less",
+          "--delay 0.5",
+          "--exec \"nx run esl-website:build:less:only\""
         ]
       }
     },

--- a/packages/esl/project.json
+++ b/packages/esl/project.json
@@ -39,8 +39,7 @@
       "options": {
         "commands": [
           "rimraf -g \"modules/**/*.{js,ts}\"",
-          "node ../../node_modules/typescript/bin/tsc --project tsconfig.build.json",
-          "nodetouch \"modules/.ts.done\""
+          "node ../../node_modules/typescript/bin/tsc --project tsconfig.build.json"
         ],
         "parallel": false,
         "cwd": "packages/esl"
@@ -52,8 +51,7 @@
       ],
       "outputs": [
         "{projectRoot}/modules/**/*.js",
-        "{projectRoot}/modules/**/*.d.ts",
-        "{projectRoot}/modules/.ts.done"
+        "{projectRoot}/modules/**/*.d.ts"
       ]
     },
     "watch:ts": {
@@ -68,11 +66,9 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          "job-ripper \"src/**/*.less\" -w worker/less.mjs -c 2",
-          "nodetouch \"modules/.less.done\""
+          "job-ripper \"src/**/*.less\" -w worker/less.mjs -c 2"
         ],
-        "cwd": "packages/esl",
-        "parallel": false
+        "cwd": "packages/esl"
       },
       "cache": true,
       "inputs": [
@@ -81,8 +77,7 @@
       ],
       "outputs": [
         "{projectRoot}/modules/**/*.css",
-        "{projectRoot}/modules/**/*.less",
-        "{projectRoot}/modules/.less.done"
+        "{projectRoot}/modules/**/*.less"
       ]
     },
     "watch:less": {
@@ -103,13 +98,12 @@
         "parallel": false,
         "cwd": "packages/esl"
       },
-      "cache": true,
+      "cache": false,
       "inputs": [
         "{projectRoot}/src/**/*.md"
       ],
       "outputs": [
-        "{projectRoot}/modules/**/*.md",
-        "{projectRoot}/modules/.docs.done"
+        "{projectRoot}/modules/**/*.md"
       ]
     },
     "watch:docs": {

--- a/packages/ui-playground/project.json
+++ b/packages/ui-playground/project.json
@@ -39,8 +39,7 @@
       "options": {
         "commands": [
           "rimraf -g \"dist/**/*.{js,ts}\"",
-          "node ../../node_modules/typescript/bin/tsc --project tsconfig.json",
-          "nodetouch \"dist/.ts.done\""
+          "node ../../node_modules/typescript/bin/tsc --project tsconfig.json"
         ],
         "parallel": false,
         "cwd": "packages/ui-playground"
@@ -52,8 +51,7 @@
       ],
       "outputs": [
         "{projectRoot}/dist/**/*.js",
-        "{projectRoot}/dist/**/*.d.ts",
-        "{projectRoot}/dist/.ts.done"
+        "{projectRoot}/dist/**/*.d.ts"
       ]
     },
     "watch:ts": {
@@ -69,11 +67,9 @@
       "dependsOn": ["^build:less"],
       "options": {
         "commands": [
-          "job-ripper \"src/**/*.less\" -w worker/less.mjs -c 2",
-          "nodetouch \"dist/.less.done\""
+          "job-ripper \"src/**/*.less\" -w worker/less.mjs -c 2"
         ],
-        "cwd": "packages/ui-playground",
-        "parallel": false
+        "cwd": "packages/ui-playground"
       },
       "cache": true,
       "inputs": [
@@ -82,8 +78,7 @@
       ],
       "outputs": [
         "{projectRoot}/dist/**/*.css",
-        "{projectRoot}/dist/**/*.less",
-        "{projectRoot}/dist/.less.done"
+        "{projectRoot}/dist/**/*.less"
       ]
     },
     "watch:less": {
@@ -104,13 +99,12 @@
         "parallel": false,
         "cwd": "packages/ui-playground"
       },
-      "cache": true,
+      "cache": false,
       "inputs": [
         "{projectRoot}/src/**/*.md"
       ],
       "outputs": [
-        "{projectRoot}/dist/**/*.md",
-        "{projectRoot}/dist/.docs.done"
+        "{projectRoot}/dist/**/*.md"
       ]
     },
     "watch:docs": {


### PR DESCRIPTION
1) TS `.ts.done` never used and never needed - so it is removed
2) For the LESS build, the solution is stable:
     - the `.less.done` marker removed
     - introducing nodemon-based debounced watch
     - other watches and chokidar in particular were not changed or replaced (no need as it works fine if it does not observe the cached result; it is a dependency for 11ty anyway)
3) For MD, the solution is mostly temporary, even if it works fine already.
     - the `.docs.done`  marker left in the architecture as an observation point for 11ty watch (due to missing 11ty debounce) 
     - Build of the MD files changed to uncachable to resolve the observation of the NX cache problem; however, as it is a copy task  at that moment, there is no necessity to cache it
4) Small enhancements in 11ty config - remove legacy 11ty-dev-sserver fix + move template engine anti-cache setting to the main file as it does not directly relate to the watch configuration.   