### PR TITLE
feat(esl-utils): dispatch scroll lock/unlock events

### DIFF
--- a/packages/esl/src/esl-utils/dom/scroll/test/utils.test.ts
+++ b/packages/esl/src/esl-utils/dom/scroll/test/utils.test.ts
@@ -250,3 +250,65 @@ describe('Function unlockScroll', () => {
       expect(isScrollLocked(target)).toBe(false);});
   });
 });
+
+describe('Scroll lock/unlock events', () => {
+  const target = document.createElement('div');
+  target.style.overflow = 'auto';
+
+  afterEach(() => unlockScroll(target));
+
+  test('lockScroll should dispatch esl:scroll:lock event', () => {
+    const handler = vi.fn();
+    target.addEventListener('esl:scroll:lock', handler);
+    lockScroll(target);
+    expect(handler).toHaveBeenCalledTimes(1);
+    target.removeEventListener('esl:scroll:lock', handler);
+  });
+
+  test('unlockScroll should dispatch esl:scroll:unlock event', () => {
+    lockScroll(target);
+    const handler = vi.fn();
+    target.addEventListener('esl:scroll:unlock', handler);
+    unlockScroll(target);
+    expect(handler).toHaveBeenCalledTimes(1);
+    target.removeEventListener('esl:scroll:unlock', handler);
+  });
+
+  test('esl:scroll:lock event should not bubble', () => {
+    const handler = vi.fn();
+    document.addEventListener('esl:scroll:lock', handler);
+    lockScroll(target);
+    expect(handler).not.toHaveBeenCalled();
+    document.removeEventListener('esl:scroll:lock', handler);
+  });
+
+  test('esl:scroll:unlock event should not bubble', () => {
+    lockScroll(target);
+    const handler = vi.fn();
+    document.addEventListener('esl:scroll:unlock', handler);
+    unlockScroll(target);
+    expect(handler).not.toHaveBeenCalled();
+    document.removeEventListener('esl:scroll:unlock', handler);
+  });
+
+  test('esl:scroll:lock event should not be cancelable', () => {
+    const handler = vi.fn((e: Event) => e.preventDefault());
+    target.addEventListener('esl:scroll:lock', handler);
+    lockScroll(target);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(isScrollLocked(target)).toBe(true);
+    target.removeEventListener('esl:scroll:lock', handler);
+  });
+
+  test('esl:scroll:unlock should not be dispatched if initiator mutex prevents unlock', () => {
+    lockScroll(target, {initiator: 'a'});
+    lockScroll(target, {initiator: 'b'});
+    const handler = vi.fn();
+    target.addEventListener('esl:scroll:unlock', handler);
+    unlockScroll(target, {initiator: 'a'});
+    expect(handler).not.toHaveBeenCalled();
+    expect(isScrollLocked(target)).toBe(true);
+    target.removeEventListener('esl:scroll:unlock', handler);
+    unlockScroll(target, {initiator: 'b'});
+  });
+});

--- a/packages/esl/src/esl-utils/dom/scroll/utils.ts
+++ b/packages/esl/src/esl-utils/dom/scroll/utils.ts
@@ -1,3 +1,4 @@
+import {dispatchCustomEvent} from '../events/misc';
 import {getListScrollParents, getScrollParent} from './parent';
 
 const $html = document.documentElement;
@@ -67,6 +68,7 @@ export function lockScroll(target: Element = $html, options: ScrollLockOptions =
   }
   scrollable.toggleAttribute('esl-scroll-lock-passive', !hasVScroll);
   scrollable.setAttribute('esl-scroll-lock', options.strategy || '');
+  dispatchCustomEvent(scrollable, 'esl:scroll:lock', {bubbles: false, cancelable: false});
   if (options.recursive && scrollable.parentElement) lockScroll(scrollable.parentElement, options);
 }
 
@@ -80,6 +82,7 @@ export function unlockScroll(target: Element = $html, options: ScrollLockOptions
   const scrollable = target === $html ? target : getScrollParent(target);
   scrollable.removeAttribute('esl-scroll-lock-passive');
   scrollable.removeAttribute('esl-scroll-lock');
+  dispatchCustomEvent(scrollable, 'esl:scroll:unlock', {bubbles: false, cancelable: false});
   if (options.recursive && scrollable.parentElement) unlockScroll(scrollable.parentElement, options);
 }
 


### PR DESCRIPTION
Add `esl:scroll:lock` and `esl:scroll:unlock` custom events dispatched on the scrollable element when scroll lock state changes. Events are non-bubbling and non-cancelable. Includes unit tests for event dispatch, propagation, and initiator mutex behavior.
