### PR TITLE
chore(site): replace archived image-size package with image-meta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10563,6 +10563,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/image-meta": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/image-meta/-/image-meta-0.2.2.tgz",
+      "integrity": "sha512-3MOLanc3sb3LNGWQl1RlQlNWURE5g32aUphrDyFeCsxBTk08iE3VNe4CwsUZ0Qs1X+EfX0+r29Sxdpza4B+yRA==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -16344,7 +16350,7 @@
         "@exadel/esl": "^6.3.0",
         "@exadel/ui-playground": "^6.3.0",
         "@juggle/resize-observer": "^3.4.0",
-        "image-size": "^2.0.2",
+        "image-meta": "^0.2.2",
         "jsdom": "^30.0.1",
         "out-url": "^1.2.2",
         "prismjs": "^1.30.0",
@@ -16390,18 +16396,6 @@
       },
       "engines": {
         "node": ">=24.0.0"
-      }
-    },
-    "packages/esl-website/node_modules/image-size": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
-      "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
-      "license": "MIT",
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=16.x"
       }
     },
     "packages/eslint-config": {

--- a/packages/esl-website/11ty/markdown.img.lib.js
+++ b/packages/esl-website/11ty/markdown.img.lib.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import sizeOf from 'image-size';
+import {imageMeta} from 'image-meta';
 
 const extractAttrs = (token) => {
   const attrs = token.attrs.reduce((acc, current) => {
@@ -38,7 +38,7 @@ const plugin = (md) => {
 
     try {
       const buffer = fs.readFileSync(src);
-      const {width, height} = sizeOf(buffer);
+      const {width, height} = imageMeta(buffer);
       attrs.width = width;
       attrs.height = height;
     } catch (e) {

--- a/packages/esl-website/package.json
+++ b/packages/esl-website/package.json
@@ -26,7 +26,7 @@
     "@exadel/esl": "^6.3.0",
     "@exadel/ui-playground": "^6.3.0",
     "@juggle/resize-observer": "^3.4.0",
-    "image-size": "^2.0.2",
+    "image-meta": "^0.2.2",
     "jsdom": "^30.0.1",
     "out-url": "^1.2.2",
     "prismjs": "^1.30.0",


### PR DESCRIPTION
Replaces the archived and unmaintained `image-size` package with `image-meta` in `esl-website`. 

`image-meta` is a lightweight, zero-dependency alternative from Unjs that provides ESM support and native `imageMeta(buffer)` image dimension extraction.

## Changes
- Updated `packages/esl-website/package.json` to replace `image-size` with `image-meta`.
- Updated `packages/esl-website/11ty/markdown.img.lib.js` to use `imageMeta` for extracting image dimensions.
- Updated `package-lock.json`.

## Checklist
- [x] Pre-commit checks passed (`npm run lint`)
- [x] Code style follows project guidelines